### PR TITLE
Fixed Tropical failing test with new definitions

### DIFF
--- a/Sources/Abstract/Adapters.swift
+++ b/Sources/Abstract/Adapters.swift
@@ -6,27 +6,88 @@ Some extensions to the standard library, to make for easier implementations of a
 
 //: ------
 
-public protocol Summable: Equatable {
-	static func + (left: Self, right: Self) -> Self
+public protocol Addable: Equatable {
+	static func add (_ left: Self, _ right: Self) -> Self
 	static var zero: Self { get }
 }
 
-extension Int: Summable { public static let zero = Int(0) }
-extension UInt: Summable { public static let zero = UInt(0) }
-extension Float: Summable { public static let zero = Float(0) }
-extension Double: Summable { public static let zero = Double(0) }
+/*:
+`add` has a special definition for `Int` and `UInt`, caused by the fact that the `.max` element MUST have the semantics of *infinite*, and has to act accordingly, that is:
+
+Int.max + a = a + Int.max = Int.max
+UInt.max + a = a + UInt.max = UInt.max
+
+This is particularly important for the `Tropical<A>` semiring: without this axiom the `zeroAnnihiliatesTheMultiplicative` law cannot be enforced.
+
+Note that this special definition of `add` has to be given for any type that is both `Addable` and `ComparableToTop`, but there's no way to generically define that in Swift.
+*/
+
+extension Int: Addable {
+	public static func add(_ left: Int, _ right: Int) -> Int {
+		switch (left,right) {
+		case (Int.max,_):
+			return Int.max
+		case (_,Int.max):
+			return Int.max
+		default:
+			return left + right
+		}
+	}
+
+	public static let zero = Int(0)
+}
+
+extension UInt: Addable {
+	public static func add(_ left: UInt, _ right: UInt) -> UInt {
+		switch (left,right) {
+		case (UInt.max,_):
+			return UInt.max
+		case (_,UInt.max):
+			return UInt.max
+		default:
+			return left + right
+		}
+	}
+
+	public static let zero = UInt(0)
+}
+
+extension Float: Addable {
+	public static func add(_ left: Float, _ right: Float) -> Float { return left + right }
+	public static let zero = Float(0)
+}
+
+extension Double: Addable {
+	public static func add(_ left: Double, _ right: Double) -> Double { return left + right }
+	public static let zero = Double(0)
+}
 
 //: ------
 
 public protocol Multipliable: Equatable {
-	static func * (left: Self, right: Self) -> Self
+	static func multiply (_ left: Self, _ right: Self) -> Self
 	static var one: Self { get }
 }
 
-extension Int: Multipliable { public static let one = Int(1) }
-extension UInt: Multipliable { public static let one = UInt(1) }
-extension Float: Multipliable { public static let one = Float(1) }
-extension Double: Multipliable { public static let one = Double(1) }
+extension Int: Multipliable {
+	public static func multiply(_ left: Int, _ right: Int) -> Int { return left * right }
+	public static let one = Int(1)
+}
+
+extension UInt: Multipliable {
+	public static func multiply(_ left: UInt, _ right: UInt) -> UInt { return left * right }
+	public static let one = UInt(1)
+}
+
+extension Float: Multipliable {
+	public static func multiply(_ left: Float, _ right: Float) -> Float { return left * right }
+	public static let one = Float(1)
+}
+
+extension Double: Multipliable {
+	public static func multiply(_ left: Double, _ right: Double) -> Double { return left * right }
+	public static let one = Double(1)
+}
 
 //: ------
 

--- a/Sources/Abstract/Semigroup.swift
+++ b/Sources/Abstract/Semigroup.swift
@@ -32,7 +32,7 @@ Each type is tested for associativity in `AbstractTests.swift`, and for testing 
 
 //: ------
 
-public struct Add<A: Summable>: Wrapper, Semigroup, Equatable {
+public struct Add<A: Addable>: Wrapper, Semigroup, Equatable {
 	public typealias Wrapped = A
 
 	public let unwrap: A
@@ -42,11 +42,7 @@ public struct Add<A: Summable>: Wrapper, Semigroup, Equatable {
 	}
 	
 	public static func <> (left: Add, right: Add) -> Add {
-		return Add(left.unwrap + right.unwrap)
-	}
-	
-	public static func == (left: Add, right: Add) -> Bool {
-		return left.unwrap == right.unwrap
+		return Add.init(A.add(left.unwrap,right.unwrap))
 	}
 }
 
@@ -62,11 +58,7 @@ public struct Multiply<A: Multipliable>: Wrapper, Semigroup, Equatable {
 	}
 	
 	public static func <> (left: Multiply, right: Multiply) -> Multiply {
-		return Multiply(left.unwrap * right.unwrap)
-	}
-	
-	public static func == (left: Multiply, right: Multiply) -> Bool {
-		return left.unwrap == right.unwrap
+		return Multiply(A.multiply(left.unwrap,right.unwrap))
 	}
 }
 
@@ -84,10 +76,6 @@ public struct Max<A: ComparableToBottom>: Wrapper, Semigroup, Equatable {
 	public static func <> (left: Max, right: Max) -> Max {
 		return Max(max(left.unwrap, right.unwrap))
 	}
-	
-	public static func == (left: Max, right: Max) -> Bool {
-		return left.unwrap == right.unwrap
-	}
 }
 
 //: ------
@@ -103,10 +91,6 @@ public struct Min<A: ComparableToTop>: Wrapper, Semigroup, Equatable {
 	
 	public static func <> (left: Min, right: Min) -> Min {
 		return Min(min(left.unwrap, right.unwrap))
-	}
-	
-	public static func == (left: Min, right: Min) -> Bool {
-		return left.unwrap == right.unwrap
 	}
 }
 
@@ -129,10 +113,6 @@ public struct And: Wrapper, Semigroup, Equatable, ExpressibleByBooleanLiteral {
 	public static func <> (left: And, right: And) -> And {
 		return And(left.unwrap && right.unwrap)
 	}
-
-	public static func == (left: And, right: And) -> Bool {
-		return left.unwrap == right.unwrap
-	}
 }
 
 //: ------
@@ -153,10 +133,6 @@ public struct Or: Wrapper, Semigroup, Equatable, ExpressibleByBooleanLiteral {
 
 	public static func <> (left: Or, right: Or) -> Or {
 		return Or(left.unwrap || right.unwrap)
-	}
-
-	public static func == (left: Or, right: Or) -> Bool {
-		return left.unwrap == right.unwrap
 	}
 }
 
@@ -181,7 +157,7 @@ public struct Endofunction<A: Equatable>: Wrapper, Semigroup, EquatableInContext
 	}
 	
 	public static func == (left: Endofunction, right: Endofunction) -> (Context) -> Bool {
-		return { context in left.call(context) == right.call(context) }
+		return { left.call($0) == right.call($0) }
 	}
 }
 
@@ -206,7 +182,7 @@ public struct FunctionS<A, S: Semigroup & Equatable>: Wrapper, Semigroup, Equata
 	}
 	
 	public static func == (left: FunctionS, right: FunctionS) -> (Context) -> Bool {
-		return { context in left.call(context) == right.call(context) }
+		return { left.call($0) == right.call($0) }
 	}
 }
 

--- a/Sources/Abstract/Semiring.swift
+++ b/Sources/Abstract/Semiring.swift
@@ -60,7 +60,7 @@ Interestingly, if for type `A` both `Additive` and `Multiplicative` are `Wrapper
 
 extension Semiring where Additive: Wrapper, Additive.Wrapped == Self {
 	public static func <>+(left: Self, right: Self) -> Self {
-		return (Additive(left) <> Additive(right)).unwrap
+		return (Additive.init(left) <> Additive.init(right)).unwrap
 	}
 
 	public static var zero: Self {
@@ -70,7 +70,7 @@ extension Semiring where Additive: Wrapper, Additive.Wrapped == Self {
 
 extension Semiring where Multiplicative: Wrapper, Multiplicative.Wrapped == Self {
 	public static func <>*(left: Self, right: Self) -> Self {
-		return (Multiplicative(left) <> Multiplicative(right)).unwrap
+		return (Multiplicative.init(left) <> Multiplicative.init(right)).unwrap
 	}
 
 	public static var one: Self {
@@ -79,8 +79,34 @@ extension Semiring where Multiplicative: Wrapper, Multiplicative.Wrapped == Self
 }
 
 /*:
-Now we can define some semirings just by defining the associated types:
+If instead the semiring is a wrapper of `A`, and both its additive and multiplicative are wrappers of `A`, we can still derive an abstract implementation for the functions:
 */
+
+extension Semiring where Self: Wrapper, Additive: Wrapper, Self.Wrapped == Additive.Wrapped {
+	public static func <>+(left: Self, right: Self) -> Self {
+		return Self.init((Additive.init(left.unwrap) <> Additive.init(right.unwrap)).unwrap)
+	}
+
+	public static var zero: Self {
+		return Self.init(Additive.empty.unwrap)
+	}
+}
+
+extension Semiring where Self: Wrapper, Multiplicative: Wrapper, Self.Wrapped == Multiplicative.Wrapped {
+	public static func <>*(left: Self, right: Self) -> Self {
+		return Self.init((Multiplicative.init(left.unwrap) <> Multiplicative.init(right.unwrap)).unwrap)
+	}
+
+	public static var one: Self {
+		return Self.init(Multiplicative.empty.unwrap)
+	}
+}
+
+/*:
+Now we can define some semirings just by defining the associated types.
+*/
+
+//: ------
 
 extension Bool: Semiring {
 	public typealias Additive = And
@@ -141,29 +167,5 @@ public struct Tropical<A: ComparableToTop & Summable & Equatable>: Wrapper, Semi
     
     public init(_ value: A) {
         self.unwrap = value
-    }
-    
-    public static func <>+(left: Tropical, right: Tropical) -> Tropical {
-        return Tropical(
-            (Additive(left.unwrap) <> Additive(right.unwrap)).unwrap
-        )
-    }
-    
-    public static func <>*(left: Tropical, right: Tropical) -> Tropical {
-        return Tropical(
-            (Multiplicative(left.unwrap) <> Multiplicative(right.unwrap)).unwrap
-        )
-    }
-
-    public static var zero: Tropical {
-        return Tropical(Additive.empty.unwrap)
-    }
-    
-    public static var one: Tropical {
-        return Tropical(Multiplicative.empty.unwrap)
-    }
-    
-    public static func == (left: Tropical, right: Tropical) -> Bool {
-        return left.unwrap == right.unwrap
     }
 }

--- a/Sources/Abstract/Semiring.swift
+++ b/Sources/Abstract/Semiring.swift
@@ -158,7 +158,7 @@ public struct FunctionSR<A,SR: Semiring & Equatable>: Wrapper, Semiring, Equatab
 A Tropical semiring is just a fancy name for a (min, +)-semiring. This semiring is called tropical to honor the Brazillian mathematician, Imre Simon, who founded tropical mathematics.
  */
 
-public struct Tropical<A: ComparableToTop & Summable & Equatable>: Wrapper, Semiring, Equatable {
+public struct Tropical<A: ComparableToTop & Addable & Equatable>: Wrapper, Semiring, Equatable {
     public typealias Wrapped = A
     public typealias Additive = Min<A>
     public typealias Multiplicative = Add<A>

--- a/Sources/Abstract/Wrapper.swift
+++ b/Sources/Abstract/Wrapper.swift
@@ -29,3 +29,13 @@ extension LawInContext where Element: Wrapper {
 		return LawInContext.isIsomorphism({ $0.unwrap }, Element.init, a)
 	}
 }
+
+/*:
+If the `Wrapped` element is `Equatable`, we can define the static `==` function for a `Wrapper` (unfortunately, the `Equatable` conformance must be declared explicitly for every wrapper).
+*/
+
+extension Wrapper where Wrapped: Equatable {
+	public static func == (left: Self, right: Self) -> Bool {
+		return left.unwrap == right.unwrap
+	}
+}

--- a/Tests/AbstractTests/ArbitraryDefinitions.swift
+++ b/Tests/AbstractTests/ArbitraryDefinitions.swift
@@ -88,7 +88,7 @@ struct TestProduct: CoArbitrary, Hashable, Arbitrary, Wrapper {
 	}
 }
 
-struct AddOf<A: Arbitrary & Summable>: Arbitrary {
+struct AddOf<A: Arbitrary & Addable>: Arbitrary {
 	let get: Add<A>
 	
 	init(_ value: A) {
@@ -237,7 +237,7 @@ struct FunctionSROf<A: CoArbitrary & Hashable, SR: Arbitrary & Semiring & Equata
 	}
 }
 
-struct TropicalOf<A: Arbitrary & ComparableToTop & Summable>: Arbitrary {
+struct TropicalOf<A: Arbitrary & ComparableToTop & Addable>: Arbitrary {
     let get: Tropical<A>
     
     init(_ value: A) {


### PR DESCRIPTION
Tropical's "annihilationByZero" test was failing because `Int.max + someInt` is not equal in general to `Int.max` but this equality is required by the semantics of `Min` (the `.max` element must be considered *infinite*).