### PR TITLE
Add Sourcery code generation for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 Abstract.xcodeproj/project.xcworkspace/xcuserdata
 Abstract.xcodeproj/xcuserdata
 Carthage/
-
+Sourcery/

--- a/Abstract.xcodeproj/project.pbxproj
+++ b/Abstract.xcodeproj/project.pbxproj
@@ -97,6 +97,9 @@
 		380A4B2A1F1BF66B002D70E0 /* BoundedSemilatticeTests.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380A4B291F1BF66B002D70E0 /* BoundedSemilatticeTests.generated.swift */; };
 		380A4B2B1F1BF66B002D70E0 /* BoundedSemilatticeTests.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380A4B291F1BF66B002D70E0 /* BoundedSemilatticeTests.generated.swift */; };
 		380A4B2C1F1BF66B002D70E0 /* BoundedSemilatticeTests.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380A4B291F1BF66B002D70E0 /* BoundedSemilatticeTests.generated.swift */; };
+		380A4B311F1BF83B002D70E0 /* SemiringTests.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380A4B301F1BF83B002D70E0 /* SemiringTests.generated.swift */; };
+		380A4B321F1BF83B002D70E0 /* SemiringTests.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380A4B301F1BF83B002D70E0 /* SemiringTests.generated.swift */; };
+		380A4B331F1BF83B002D70E0 /* SemiringTests.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380A4B301F1BF83B002D70E0 /* SemiringTests.generated.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -161,6 +164,8 @@
 		380A4B241F1BF5AC002D70E0 /* CommutativeMonoidTests.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommutativeMonoidTests.generated.swift; sourceTree = "<group>"; };
 		380A4B281F1BF605002D70E0 /* BoundedSemilatticeTests.stencil */ = {isa = PBXFileReference; lastKnownFileType = text; path = BoundedSemilatticeTests.stencil; sourceTree = "<group>"; };
 		380A4B291F1BF66B002D70E0 /* BoundedSemilatticeTests.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BoundedSemilatticeTests.generated.swift; sourceTree = "<group>"; };
+		380A4B2D1F1BF743002D70E0 /* SemiringTests.stencil */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = SemiringTests.stencil; sourceTree = "<group>"; };
+		380A4B301F1BF83B002D70E0 /* SemiringTests.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SemiringTests.generated.swift; sourceTree = "<group>"; };
 		3853BF9D1EF11D7400791099 /* Wrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Wrapper.swift; sourceTree = "<group>"; };
 		3853BF9F1EF1294400791099 /* Semiring.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Semiring.swift; sourceTree = "<group>"; };
 		38943A681EEC25AE00F587AD /* AbstractTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AbstractTests.swift; sourceTree = "<group>"; };
@@ -277,6 +282,7 @@
 				380A4B1E1F1BD550002D70E0 /* MonoidTests.stencil */,
 				380A4B231F1BE3F9002D70E0 /* CommutativeMonoidTests.stencil */,
 				380A4B281F1BF605002D70E0 /* BoundedSemilatticeTests.stencil */,
+				380A4B2D1F1BF743002D70E0 /* SemiringTests.stencil */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -338,6 +344,7 @@
 		38D737BF1EE9A711000BAF0C /* AbstractTests */ = {
 			isa = PBXGroup;
 			children = (
+				380A4B301F1BF83B002D70E0 /* SemiringTests.generated.swift */,
 				38943A681EEC25AE00F587AD /* AbstractTests.swift */,
 				38943A731EEC2CF700F587AD /* ArbitraryDefinitions.swift */,
 				380A4B291F1BF66B002D70E0 /* BoundedSemilatticeTests.generated.swift */,
@@ -668,6 +675,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				380A4B321F1BF83B002D70E0 /* SemiringTests.generated.swift in Sources */,
 				380A4B211F1BE383002D70E0 /* MonoidTests.generated.swift in Sources */,
 				380A4B1B1F1B775F002D70E0 /* WrapperTests.generated.swift in Sources */,
 				380A4B161F1B7336002D70E0 /* SemigroupTests.generated.swift in Sources */,
@@ -705,6 +713,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				380A4B331F1BF83B002D70E0 /* SemiringTests.generated.swift in Sources */,
 				380A4B221F1BE383002D70E0 /* MonoidTests.generated.swift in Sources */,
 				380A4B1C1F1B775F002D70E0 /* WrapperTests.generated.swift in Sources */,
 				380A4B171F1B7336002D70E0 /* SemigroupTests.generated.swift in Sources */,
@@ -764,6 +773,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				380A4B311F1BF83B002D70E0 /* SemiringTests.generated.swift in Sources */,
 				380A4B201F1BE383002D70E0 /* MonoidTests.generated.swift in Sources */,
 				380A4B1A1F1B775F002D70E0 /* WrapperTests.generated.swift in Sources */,
 				380A4B151F1B7336002D70E0 /* SemigroupTests.generated.swift in Sources */,

--- a/Abstract.xcodeproj/project.pbxproj
+++ b/Abstract.xcodeproj/project.pbxproj
@@ -88,6 +88,15 @@
 		380A4B1A1F1B775F002D70E0 /* WrapperTests.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380A4B191F1B775F002D70E0 /* WrapperTests.generated.swift */; };
 		380A4B1B1F1B775F002D70E0 /* WrapperTests.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380A4B191F1B775F002D70E0 /* WrapperTests.generated.swift */; };
 		380A4B1C1F1B775F002D70E0 /* WrapperTests.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380A4B191F1B775F002D70E0 /* WrapperTests.generated.swift */; };
+		380A4B201F1BE383002D70E0 /* MonoidTests.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380A4B1F1F1BE383002D70E0 /* MonoidTests.generated.swift */; };
+		380A4B211F1BE383002D70E0 /* MonoidTests.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380A4B1F1F1BE383002D70E0 /* MonoidTests.generated.swift */; };
+		380A4B221F1BE383002D70E0 /* MonoidTests.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380A4B1F1F1BE383002D70E0 /* MonoidTests.generated.swift */; };
+		380A4B251F1BF5BD002D70E0 /* CommutativeMonoidTests.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380A4B241F1BF5AC002D70E0 /* CommutativeMonoidTests.generated.swift */; };
+		380A4B261F1BF5BE002D70E0 /* CommutativeMonoidTests.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380A4B241F1BF5AC002D70E0 /* CommutativeMonoidTests.generated.swift */; };
+		380A4B271F1BF5BF002D70E0 /* CommutativeMonoidTests.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380A4B241F1BF5AC002D70E0 /* CommutativeMonoidTests.generated.swift */; };
+		380A4B2A1F1BF66B002D70E0 /* BoundedSemilatticeTests.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380A4B291F1BF66B002D70E0 /* BoundedSemilatticeTests.generated.swift */; };
+		380A4B2B1F1BF66B002D70E0 /* BoundedSemilatticeTests.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380A4B291F1BF66B002D70E0 /* BoundedSemilatticeTests.generated.swift */; };
+		380A4B2C1F1BF66B002D70E0 /* BoundedSemilatticeTests.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380A4B291F1BF66B002D70E0 /* BoundedSemilatticeTests.generated.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -146,6 +155,12 @@
 		380A4B141F1B7336002D70E0 /* SemigroupTests.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SemigroupTests.generated.swift; sourceTree = "<group>"; };
 		380A4B181F1B7624002D70E0 /* WrapperTests.stencil */ = {isa = PBXFileReference; lastKnownFileType = text; path = WrapperTests.stencil; sourceTree = "<group>"; };
 		380A4B191F1B775F002D70E0 /* WrapperTests.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrapperTests.generated.swift; sourceTree = "<group>"; };
+		380A4B1E1F1BD550002D70E0 /* MonoidTests.stencil */ = {isa = PBXFileReference; lastKnownFileType = text; path = MonoidTests.stencil; sourceTree = "<group>"; };
+		380A4B1F1F1BE383002D70E0 /* MonoidTests.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MonoidTests.generated.swift; sourceTree = "<group>"; };
+		380A4B231F1BE3F9002D70E0 /* CommutativeMonoidTests.stencil */ = {isa = PBXFileReference; lastKnownFileType = text; path = CommutativeMonoidTests.stencil; sourceTree = "<group>"; };
+		380A4B241F1BF5AC002D70E0 /* CommutativeMonoidTests.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommutativeMonoidTests.generated.swift; sourceTree = "<group>"; };
+		380A4B281F1BF605002D70E0 /* BoundedSemilatticeTests.stencil */ = {isa = PBXFileReference; lastKnownFileType = text; path = BoundedSemilatticeTests.stencil; sourceTree = "<group>"; };
+		380A4B291F1BF66B002D70E0 /* BoundedSemilatticeTests.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BoundedSemilatticeTests.generated.swift; sourceTree = "<group>"; };
 		3853BF9D1EF11D7400791099 /* Wrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Wrapper.swift; sourceTree = "<group>"; };
 		3853BF9F1EF1294400791099 /* Semiring.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Semiring.swift; sourceTree = "<group>"; };
 		38943A681EEC25AE00F587AD /* AbstractTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AbstractTests.swift; sourceTree = "<group>"; };
@@ -259,6 +274,9 @@
 			children = (
 				380A4B0D1F1B71AA002D70E0 /* SemigroupTests.stencil */,
 				380A4B181F1B7624002D70E0 /* WrapperTests.stencil */,
+				380A4B1E1F1BD550002D70E0 /* MonoidTests.stencil */,
+				380A4B231F1BE3F9002D70E0 /* CommutativeMonoidTests.stencil */,
+				380A4B281F1BF605002D70E0 /* BoundedSemilatticeTests.stencil */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -322,6 +340,9 @@
 			children = (
 				38943A681EEC25AE00F587AD /* AbstractTests.swift */,
 				38943A731EEC2CF700F587AD /* ArbitraryDefinitions.swift */,
+				380A4B291F1BF66B002D70E0 /* BoundedSemilatticeTests.generated.swift */,
+				380A4B241F1BF5AC002D70E0 /* CommutativeMonoidTests.generated.swift */,
+				380A4B1F1F1BE383002D70E0 /* MonoidTests.generated.swift */,
 				380A4B141F1B7336002D70E0 /* SemigroupTests.generated.swift */,
 				380A4B191F1B775F002D70E0 /* WrapperTests.generated.swift */,
 			);
@@ -647,11 +668,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				380A4B211F1BE383002D70E0 /* MonoidTests.generated.swift in Sources */,
 				380A4B1B1F1B775F002D70E0 /* WrapperTests.generated.swift in Sources */,
 				380A4B161F1B7336002D70E0 /* SemigroupTests.generated.swift in Sources */,
+				380A4B261F1BF5BE002D70E0 /* CommutativeMonoidTests.generated.swift in Sources */,
 				0950FF071EFC5C8100513DF7 /* AbstractTests.swift in Sources */,
 				0950FF081EFC5C8100513DF7 /* ArbitraryDefinitions.swift in Sources */,
 				0951F2401F095AD500EA362C /* Operators.swift in Sources */,
+				380A4B2B1F1BF66B002D70E0 /* BoundedSemilatticeTests.generated.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -681,11 +705,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				380A4B221F1BE383002D70E0 /* MonoidTests.generated.swift in Sources */,
 				380A4B1C1F1B775F002D70E0 /* WrapperTests.generated.swift in Sources */,
 				380A4B171F1B7336002D70E0 /* SemigroupTests.generated.swift in Sources */,
+				380A4B271F1BF5BF002D70E0 /* CommutativeMonoidTests.generated.swift in Sources */,
 				0950FF3F1F0948D000513DF7 /* AbstractTests.swift in Sources */,
 				0950FF401F0948D000513DF7 /* ArbitraryDefinitions.swift in Sources */,
 				0951F23E1F095AD400EA362C /* Operators.swift in Sources */,
+				380A4B2C1F1BF66B002D70E0 /* BoundedSemilatticeTests.generated.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -737,11 +764,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				380A4B201F1BE383002D70E0 /* MonoidTests.generated.swift in Sources */,
 				380A4B1A1F1B775F002D70E0 /* WrapperTests.generated.swift in Sources */,
 				380A4B151F1B7336002D70E0 /* SemigroupTests.generated.swift in Sources */,
+				380A4B251F1BF5BD002D70E0 /* CommutativeMonoidTests.generated.swift in Sources */,
 				0950FF861F094AB500513DF7 /* AbstractTests.swift in Sources */,
 				0950FF871F094AB500513DF7 /* ArbitraryDefinitions.swift in Sources */,
 				0951F2411F095AD600EA362C /* Operators.swift in Sources */,
+				380A4B2A1F1BF66B002D70E0 /* BoundedSemilatticeTests.generated.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Abstract.xcodeproj/project.pbxproj
+++ b/Abstract.xcodeproj/project.pbxproj
@@ -320,10 +320,10 @@
 		38D737BF1EE9A711000BAF0C /* AbstractTests */ = {
 			isa = PBXGroup;
 			children = (
-				380A4B191F1B775F002D70E0 /* WrapperTests.generated.swift */,
-				380A4B141F1B7336002D70E0 /* SemigroupTests.generated.swift */,
 				38943A681EEC25AE00F587AD /* AbstractTests.swift */,
 				38943A731EEC2CF700F587AD /* ArbitraryDefinitions.swift */,
+				380A4B141F1B7336002D70E0 /* SemigroupTests.generated.swift */,
+				380A4B191F1B775F002D70E0 /* WrapperTests.generated.swift */,
 			);
 			path = AbstractTests;
 			sourceTree = "<group>";
@@ -616,7 +616,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "bash Sourcery/sourceryTests.sh";
+			shellScript = "bash sourceryTests.sh";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Abstract.xcodeproj/project.pbxproj
+++ b/Abstract.xcodeproj/project.pbxproj
@@ -21,7 +21,7 @@
 		0950FEF81EFC5C7900513DF7 /* CommutativeMonoid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38B83C991EED85C6007AB12A /* CommutativeMonoid.swift */; };
 		0950FEF91EFC5C7900513DF7 /* Monoid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38943A781EEC4EFF00F587AD /* Monoid.swift */; };
 		0950FEFA1EFC5C7900513DF7 /* Semiring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3853BF9F1EF1294400791099 /* Semiring.swift */; };
-		0950FF071EFC5C8100513DF7 /* AbstractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38943A681EEC25AE00F587AD /* AbstractTests.swift */; };
+		0950FF071EFC5C8100513DF7 /* HomomorphismTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38943A681EEC25AE00F587AD /* HomomorphismTests.swift */; };
 		0950FF081EFC5C8100513DF7 /* ArbitraryDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38943A731EEC2CF700F587AD /* ArbitraryDefinitions.swift */; };
 		0950FF231F09480A00513DF7 /* Abstract_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0950FF1A1F09480A00513DF7 /* Abstract_tvOS.framework */; };
 		0950FF311F09488B00513DF7 /* Adapters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38943A761EEC31DA00F587AD /* Adapters.swift */; };
@@ -38,7 +38,7 @@
 		0950FF3C1F09488B00513DF7 /* Collections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38B83C971EED83EF007AB12A /* Collections.swift */; };
 		0950FF3D1F09488B00513DF7 /* Comparison.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38B83C931EED72F3007AB12A /* Comparison.swift */; };
 		0950FF3E1F09488B00513DF7 /* Predicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38B83C911EED6E33007AB12A /* Predicate.swift */; };
-		0950FF3F1F0948D000513DF7 /* AbstractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38943A681EEC25AE00F587AD /* AbstractTests.swift */; };
+		0950FF3F1F0948D000513DF7 /* HomomorphismTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38943A681EEC25AE00F587AD /* HomomorphismTests.swift */; };
 		0950FF401F0948D000513DF7 /* ArbitraryDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38943A731EEC2CF700F587AD /* ArbitraryDefinitions.swift */; };
 		0950FF4E1F094A2C00513DF7 /* Adapters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38943A761EEC31DA00F587AD /* Adapters.swift */; };
 		0950FF4F1F094A2C00513DF7 /* BoundedSemilattice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38B83C9B1EED8A15007AB12A /* BoundedSemilattice.swift */; };
@@ -69,7 +69,7 @@
 		0950FF831F094AA100513DF7 /* Collections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38B83C971EED83EF007AB12A /* Collections.swift */; };
 		0950FF841F094AA100513DF7 /* Comparison.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38B83C931EED72F3007AB12A /* Comparison.swift */; };
 		0950FF851F094AA100513DF7 /* Predicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38B83C911EED6E33007AB12A /* Predicate.swift */; };
-		0950FF861F094AB500513DF7 /* AbstractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38943A681EEC25AE00F587AD /* AbstractTests.swift */; };
+		0950FF861F094AB500513DF7 /* HomomorphismTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38943A681EEC25AE00F587AD /* HomomorphismTests.swift */; };
 		0950FF871F094AB500513DF7 /* ArbitraryDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38943A731EEC2CF700F587AD /* ArbitraryDefinitions.swift */; };
 		0951F23B1F095ACF00EA362C /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0951F23A1F095ACF00EA362C /* Operators.swift */; };
 		0951F23C1F095AD200EA362C /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0951F23A1F095ACF00EA362C /* Operators.swift */; };
@@ -166,9 +166,10 @@
 		380A4B291F1BF66B002D70E0 /* BoundedSemilatticeTests.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BoundedSemilatticeTests.generated.swift; sourceTree = "<group>"; };
 		380A4B2D1F1BF743002D70E0 /* SemiringTests.stencil */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = SemiringTests.stencil; sourceTree = "<group>"; };
 		380A4B301F1BF83B002D70E0 /* SemiringTests.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SemiringTests.generated.swift; sourceTree = "<group>"; };
+		380A4B351F1BFA9F002D70E0 /* LinuxMain.stencil */ = {isa = PBXFileReference; lastKnownFileType = text; path = LinuxMain.stencil; sourceTree = "<group>"; };
 		3853BF9D1EF11D7400791099 /* Wrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Wrapper.swift; sourceTree = "<group>"; };
 		3853BF9F1EF1294400791099 /* Semiring.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Semiring.swift; sourceTree = "<group>"; };
-		38943A681EEC25AE00F587AD /* AbstractTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AbstractTests.swift; sourceTree = "<group>"; };
+		38943A681EEC25AE00F587AD /* HomomorphismTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomomorphismTests.swift; sourceTree = "<group>"; };
 		38943A731EEC2CF700F587AD /* ArbitraryDefinitions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArbitraryDefinitions.swift; sourceTree = "<group>"; };
 		38943A761EEC31DA00F587AD /* Adapters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Adapters.swift; sourceTree = "<group>"; };
 		38943A781EEC4EFF00F587AD /* Monoid.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Monoid.swift; sourceTree = "<group>"; };
@@ -269,6 +270,7 @@
 		380A4B0B1F1B71AA002D70E0 /* Templates */ = {
 			isa = PBXGroup;
 			children = (
+				380A4B341F1BFA9F002D70E0 /* Other */,
 				380A4B0C1F1B71AA002D70E0 /* Tests */,
 			);
 			path = Templates;
@@ -277,14 +279,22 @@
 		380A4B0C1F1B71AA002D70E0 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				380A4B0D1F1B71AA002D70E0 /* SemigroupTests.stencil */,
-				380A4B181F1B7624002D70E0 /* WrapperTests.stencil */,
-				380A4B1E1F1BD550002D70E0 /* MonoidTests.stencil */,
-				380A4B231F1BE3F9002D70E0 /* CommutativeMonoidTests.stencil */,
 				380A4B281F1BF605002D70E0 /* BoundedSemilatticeTests.stencil */,
+				380A4B231F1BE3F9002D70E0 /* CommutativeMonoidTests.stencil */,
+				380A4B1E1F1BD550002D70E0 /* MonoidTests.stencil */,
+				380A4B0D1F1B71AA002D70E0 /* SemigroupTests.stencil */,
 				380A4B2D1F1BF743002D70E0 /* SemiringTests.stencil */,
+				380A4B181F1B7624002D70E0 /* WrapperTests.stencil */,
 			);
 			path = Tests;
+			sourceTree = "<group>";
+		};
+		380A4B341F1BFA9F002D70E0 /* Other */ = {
+			isa = PBXGroup;
+			children = (
+				380A4B351F1BFA9F002D70E0 /* LinuxMain.stencil */,
+			);
+			path = Other;
 			sourceTree = "<group>";
 		};
 		38943A6A1EEC287000F587AD /* Frameworks */ = {
@@ -344,13 +354,13 @@
 		38D737BF1EE9A711000BAF0C /* AbstractTests */ = {
 			isa = PBXGroup;
 			children = (
-				380A4B301F1BF83B002D70E0 /* SemiringTests.generated.swift */,
-				38943A681EEC25AE00F587AD /* AbstractTests.swift */,
 				38943A731EEC2CF700F587AD /* ArbitraryDefinitions.swift */,
 				380A4B291F1BF66B002D70E0 /* BoundedSemilatticeTests.generated.swift */,
 				380A4B241F1BF5AC002D70E0 /* CommutativeMonoidTests.generated.swift */,
+				38943A681EEC25AE00F587AD /* HomomorphismTests.swift */,
 				380A4B1F1F1BE383002D70E0 /* MonoidTests.generated.swift */,
 				380A4B141F1B7336002D70E0 /* SemigroupTests.generated.swift */,
+				380A4B301F1BF83B002D70E0 /* SemiringTests.generated.swift */,
 				380A4B191F1B775F002D70E0 /* WrapperTests.generated.swift */,
 			);
 			path = AbstractTests;
@@ -680,7 +690,7 @@
 				380A4B1B1F1B775F002D70E0 /* WrapperTests.generated.swift in Sources */,
 				380A4B161F1B7336002D70E0 /* SemigroupTests.generated.swift in Sources */,
 				380A4B261F1BF5BE002D70E0 /* CommutativeMonoidTests.generated.swift in Sources */,
-				0950FF071EFC5C8100513DF7 /* AbstractTests.swift in Sources */,
+				0950FF071EFC5C8100513DF7 /* HomomorphismTests.swift in Sources */,
 				0950FF081EFC5C8100513DF7 /* ArbitraryDefinitions.swift in Sources */,
 				0951F2401F095AD500EA362C /* Operators.swift in Sources */,
 				380A4B2B1F1BF66B002D70E0 /* BoundedSemilatticeTests.generated.swift in Sources */,
@@ -718,7 +728,7 @@
 				380A4B1C1F1B775F002D70E0 /* WrapperTests.generated.swift in Sources */,
 				380A4B171F1B7336002D70E0 /* SemigroupTests.generated.swift in Sources */,
 				380A4B271F1BF5BF002D70E0 /* CommutativeMonoidTests.generated.swift in Sources */,
-				0950FF3F1F0948D000513DF7 /* AbstractTests.swift in Sources */,
+				0950FF3F1F0948D000513DF7 /* HomomorphismTests.swift in Sources */,
 				0950FF401F0948D000513DF7 /* ArbitraryDefinitions.swift in Sources */,
 				0951F23E1F095AD400EA362C /* Operators.swift in Sources */,
 				380A4B2C1F1BF66B002D70E0 /* BoundedSemilatticeTests.generated.swift in Sources */,
@@ -778,7 +788,7 @@
 				380A4B1A1F1B775F002D70E0 /* WrapperTests.generated.swift in Sources */,
 				380A4B151F1B7336002D70E0 /* SemigroupTests.generated.swift in Sources */,
 				380A4B251F1BF5BD002D70E0 /* CommutativeMonoidTests.generated.swift in Sources */,
-				0950FF861F094AB500513DF7 /* AbstractTests.swift in Sources */,
+				0950FF861F094AB500513DF7 /* HomomorphismTests.swift in Sources */,
 				0950FF871F094AB500513DF7 /* ArbitraryDefinitions.swift in Sources */,
 				0951F2411F095AD600EA362C /* Operators.swift in Sources */,
 				380A4B2A1F1BF66B002D70E0 /* BoundedSemilatticeTests.generated.swift in Sources */,

--- a/Abstract.xcodeproj/project.pbxproj
+++ b/Abstract.xcodeproj/project.pbxproj
@@ -81,6 +81,13 @@
 		0951F2481F09690C00EA362C /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0951F2421F09690200EA362C /* SwiftCheck.framework */; };
 		0951F24C1F096B7F00EA362C /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0951F2441F09690200EA362C /* SwiftCheck.framework */; };
 		0951F24E1F096C3A00EA362C /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0951F2431F09690200EA362C /* SwiftCheck.framework */; };
+		380A4B131F1B726E002D70E0 /* SwiftCheck.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0951F2431F09690200EA362C /* SwiftCheck.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		380A4B151F1B7336002D70E0 /* SemigroupTests.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380A4B141F1B7336002D70E0 /* SemigroupTests.generated.swift */; };
+		380A4B161F1B7336002D70E0 /* SemigroupTests.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380A4B141F1B7336002D70E0 /* SemigroupTests.generated.swift */; };
+		380A4B171F1B7336002D70E0 /* SemigroupTests.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380A4B141F1B7336002D70E0 /* SemigroupTests.generated.swift */; };
+		380A4B1A1F1B775F002D70E0 /* WrapperTests.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380A4B191F1B775F002D70E0 /* WrapperTests.generated.swift */; };
+		380A4B1B1F1B775F002D70E0 /* WrapperTests.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380A4B191F1B775F002D70E0 /* WrapperTests.generated.swift */; };
+		380A4B1C1F1B775F002D70E0 /* WrapperTests.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380A4B191F1B775F002D70E0 /* WrapperTests.generated.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -110,13 +117,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		380A4B121F1B7266002D70E0 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				380A4B131F1B726E002D70E0 /* SwiftCheck.framework in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		0950FF011EFC5C7900513DF7 /* Abstract.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Abstract.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		0950FF021EFC5C7900513DF7 /* Abstract copy-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Abstract copy-Info.plist"; path = "/Users/bkase/Abstract/Abstract copy-Info.plist"; sourceTree = "<absolute>"; };
 		0950FF121EFC5C8100513DF7 /* Abstract-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Abstract-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		0950FF131EFC5C8100513DF7 /* AbstractTests copy-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "AbstractTests copy-Info.plist"; path = "/Users/bkase/Abstract/AbstractTests copy-Info.plist"; sourceTree = "<absolute>"; };
 		0950FF1A1F09480A00513DF7 /* Abstract_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Abstract_tvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0950FF221F09480A00513DF7 /* Abstract-tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Abstract-tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		0950FF461F094A0100513DF7 /* Abstract_watchOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Abstract_watchOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -127,6 +142,10 @@
 		0951F2431F09690200EA362C /* SwiftCheck.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftCheck.framework; path = Carthage/Build/Mac/SwiftCheck.framework; sourceTree = "<group>"; };
 		0951F2441F09690200EA362C /* SwiftCheck.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftCheck.framework; path = Carthage/Build/tvOS/SwiftCheck.framework; sourceTree = "<group>"; };
 		09F9FD0E1EEE5CE8002342E5 /* Homomorphism.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Homomorphism.swift; sourceTree = "<group>"; };
+		380A4B0D1F1B71AA002D70E0 /* SemigroupTests.stencil */ = {isa = PBXFileReference; lastKnownFileType = text; path = SemigroupTests.stencil; sourceTree = "<group>"; };
+		380A4B141F1B7336002D70E0 /* SemigroupTests.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SemigroupTests.generated.swift; sourceTree = "<group>"; };
+		380A4B181F1B7624002D70E0 /* WrapperTests.stencil */ = {isa = PBXFileReference; lastKnownFileType = text; path = WrapperTests.stencil; sourceTree = "<group>"; };
+		380A4B191F1B775F002D70E0 /* WrapperTests.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrapperTests.generated.swift; sourceTree = "<group>"; };
 		3853BF9D1EF11D7400791099 /* Wrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Wrapper.swift; sourceTree = "<group>"; };
 		3853BF9F1EF1294400791099 /* Semiring.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Semiring.swift; sourceTree = "<group>"; };
 		38943A681EEC25AE00F587AD /* AbstractTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AbstractTests.swift; sourceTree = "<group>"; };
@@ -227,6 +246,23 @@
 			path = Abstract;
 			sourceTree = "<group>";
 		};
+		380A4B0B1F1B71AA002D70E0 /* Templates */ = {
+			isa = PBXGroup;
+			children = (
+				380A4B0C1F1B71AA002D70E0 /* Tests */,
+			);
+			path = Templates;
+			sourceTree = "<group>";
+		};
+		380A4B0C1F1B71AA002D70E0 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				380A4B0D1F1B71AA002D70E0 /* SemigroupTests.stencil */,
+				380A4B181F1B7624002D70E0 /* WrapperTests.stencil */,
+			);
+			path = Tests;
+			sourceTree = "<group>";
+		};
 		38943A6A1EEC287000F587AD /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -250,17 +286,16 @@
 		38D737B41EE9A6BA000BAF0C = {
 			isa = PBXGroup;
 			children = (
-				38B83C9D1EED8D11007AB12A /* README.md */,
 				38D737DF1EE9A745000BAF0C /* Abstract.h */,
+				38B83C9D1EED8D11007AB12A /* README.md */,
 				38D737E01EE9A745000BAF0C /* Info.plist */,
 				38D737E11EE9A761000BAF0C /* InfoTests.plist */,
 				38D737BB1EE9A711000BAF0C /* Package.swift */,
 				38943A6A1EEC287000F587AD /* Frameworks */,
 				38D737C81EE9A729000BAF0C /* Products */,
 				38D737BC1EE9A711000BAF0C /* Sources */,
+				380A4B0B1F1B71AA002D70E0 /* Templates */,
 				38D737BE1EE9A711000BAF0C /* Tests */,
-				0950FF021EFC5C7900513DF7 /* Abstract copy-Info.plist */,
-				0950FF131EFC5C8100513DF7 /* AbstractTests copy-Info.plist */,
 			);
 			sourceTree = "<group>";
 		};
@@ -285,6 +320,8 @@
 		38D737BF1EE9A711000BAF0C /* AbstractTests */ = {
 			isa = PBXGroup;
 			children = (
+				380A4B191F1B775F002D70E0 /* WrapperTests.generated.swift */,
+				380A4B141F1B7336002D70E0 /* SemigroupTests.generated.swift */,
 				38943A681EEC25AE00F587AD /* AbstractTests.swift */,
 				38943A731EEC2CF700F587AD /* ArbitraryDefinitions.swift */,
 			);
@@ -451,9 +488,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 0950FF751F094A6600513DF7 /* Build configuration list for PBXNativeTarget "AbstractTests" */;
 			buildPhases = (
+				380A4B1D1F1B77DD002D70E0 /* ShellScript */,
 				0950FF651F094A6600513DF7 /* Sources */,
 				0950FF661F094A6600513DF7 /* Frameworks */,
-				0950FF671F094A6600513DF7 /* Resources */,
+				380A4B121F1B7266002D70E0 /* CopyFiles */,
 			);
 			buildRules = (
 			);
@@ -564,14 +602,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		0950FF671F094A6600513DF7 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		380A4B1D1F1B77DD002D70E0 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
 			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "bash Sourcery/sourceryTests.sh";
 		};
-/* End PBXResourcesBuildPhase section */
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		0950FEEC1EFC5C7900513DF7 /* Sources */ = {
@@ -600,6 +647,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				380A4B1B1F1B775F002D70E0 /* WrapperTests.generated.swift in Sources */,
+				380A4B161F1B7336002D70E0 /* SemigroupTests.generated.swift in Sources */,
 				0950FF071EFC5C8100513DF7 /* AbstractTests.swift in Sources */,
 				0950FF081EFC5C8100513DF7 /* ArbitraryDefinitions.swift in Sources */,
 				0951F2401F095AD500EA362C /* Operators.swift in Sources */,
@@ -632,6 +681,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				380A4B1C1F1B775F002D70E0 /* WrapperTests.generated.swift in Sources */,
+				380A4B171F1B7336002D70E0 /* SemigroupTests.generated.swift in Sources */,
 				0950FF3F1F0948D000513DF7 /* AbstractTests.swift in Sources */,
 				0950FF401F0948D000513DF7 /* ArbitraryDefinitions.swift in Sources */,
 				0951F23E1F095AD400EA362C /* Operators.swift in Sources */,
@@ -686,6 +737,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				380A4B1A1F1B775F002D70E0 /* WrapperTests.generated.swift in Sources */,
+				380A4B151F1B7336002D70E0 /* SemigroupTests.generated.swift in Sources */,
 				0950FF861F094AB500513DF7 /* AbstractTests.swift in Sources */,
 				0950FF871F094AB500513DF7 /* ArbitraryDefinitions.swift in Sources */,
 				0951F2411F095AD600EA362C /* Operators.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -47,10 +47,11 @@ Test code is automatically generated for all types using [Sourcery](https://gith
 
 The script in `sourceryTests.sh` requires Sourcery to scan source files in `Sources/Abstract` and generate code with the templates defined in `Templates/Tests`; generated files are put in `Tests/AbstractTests` and are recognizable by the `.generated` in the name: these files must not be edited manually.
 
-To tell Sourcery what to do some annotations are written before each type definition, as follows:
+Sourcery is just a tool for code generation: at compile time the actual check for a type to conform to a certain protocol is guaranteed by the functions defined in the `Law` namespace, thus the generated tests are associated to specific algebraic structures rather than particular properties (like "associative" or "idempotent").
 
-- wrapper: identifies the type as requiring test generation for Wrapper laws conformance;
-- semigroup: identifies the type as requiring test generation for Semigroup laws conformance (associativity);
+Sourcery will automatically generate tests for all types conforming to the protocols representing the algebraic data structures considered, and some annotations associated with a type (in the form `// sourcery: annotation`) will allow some fine tuning:
+
+- ignore = "value": Sourcery will not generate tests related to that protocol for that type; "value" is the protocol's name (like "Semigroup" or "CommuntativeMonoid");
 - genericArbitraryTypes = "value": for generic types it defines the concrete type to be used in tests; if more than one generic type is present, all types must be separated by a comma;
 - requiredContext = "value": use `LawInContext` instead of `Law`; "value" is the context type; this is required if the type wraps a function.
 

--- a/README.md
+++ b/README.md
@@ -38,3 +38,19 @@ A plain translation into Swift from a language with a more sophisticated type sy
 One final note: the closest thing to this that I could find on GitHub is the [Algebra](https://github.com/typelift/Algebra) library from typelift (the same organization behind the glorious SwiftCheck library). There are differences between this library and `Algebra`, mainly there is a plain definition of `Monoid` instead of `Additive` and `Multiplicative`. But a huge difference is probably the fact that `Algebra` is supposed to be an "exploration", like many other explorations out there of functional concepts applyied to Swift, that I also did and keep doing, trying to push the boudaries of Swift's expressivity. In general I wanted to take a different path in defining what are basically the same things, but the exploration I'm interested in is about practical applications rather than finding ways to express the theoretical concepts of abstract algebra in Swift's type system.
 
 So, this repo is my contribution and proposal to the cause.
+
+------
+
+## Sourcery usage
+
+Test code is automatically generated for all types using [Sourcery](https://github.com/krzysztofzablocki/Sourcery).
+
+The script in `sourceryTests.sh` requires Sourcery to scan source files in `Sources/Abstract` and generate code with the templates defined in `Templates/Tests`; generated files are put in `Tests/AbstractTests` and are recognizable by the `.generated` in the name: these files must not be edited manually.
+
+To tell Sourcery what to do some annotations are written before each type definition, as follows:
+
+- wrapper: identifies the type as requiring test generation for Wrapper laws conformance;
+- semigroup: identifies the type as requiring test generation for Semigroup laws conformance (associativity);
+- genericArbitraryTypes = "value": for generic types it defines the concrete type to be used in tests; if more than one generic type is present, all types must be separated by a comma;
+- requiredContext = "value": use `LawInContext` instead of `Law`; "value" is the context type; this is required if the type wraps a function.
+

--- a/Sources/Abstract/BoundedSemilattice.swift
+++ b/Sources/Abstract/BoundedSemilattice.swift
@@ -44,6 +44,8 @@ extension Or: BoundedSemilattice {}
 
 //: ------
 
+// sourcery: genericArbitraryTypes = "Int,TestStructure"
+// sourcery: requiredContext = "Int"
 public struct FunctionBS<A, M: BoundedSemilattice & Equatable>: Wrapper, BoundedSemilattice, EquatableInContext {
 	public typealias Wrapped = (A) -> M
 	public typealias Context = A

--- a/Sources/Abstract/CommutativeMonoid.swift
+++ b/Sources/Abstract/CommutativeMonoid.swift
@@ -52,6 +52,8 @@ extension Or: CommutativeMonoid {}
 
 //: ------
 
+// sourcery: genericArbitraryTypes = "Int,TestStructure"
+// sourcery: requiredContext = "Int"
 public struct FunctionCM<A, M: CommutativeMonoid & Equatable>: Wrapper, CommutativeMonoid, EquatableInContext {
 	public typealias Wrapped = (A) -> M
 	public typealias Context = A

--- a/Sources/Abstract/Monoid.swift
+++ b/Sources/Abstract/Monoid.swift
@@ -94,6 +94,8 @@ extension Endofunction: Monoid {
 
 //: ------
 
+// sourcery: genericArbitraryTypes = "Int,TestStructure"
+// sourcery: requiredContext = "Int"
 public struct FunctionM<A, M: Monoid & Equatable>: Wrapper,  Monoid, EquatableInContext {
 	public typealias Wrapped = (A) -> M
 	public typealias Context = A

--- a/Sources/Abstract/Semigroup.swift
+++ b/Sources/Abstract/Semigroup.swift
@@ -34,6 +34,9 @@ Each type is tested for associativity in `AbstractTests.swift`, and for testing 
 
 //: ------
 
+// sourcery: semigroup
+// sourcery: wrapper
+// sourcery: genericArbitraryTypes = "Int"
 public struct Add<A: Addable>: Wrapper, Semigroup, Equatable {
 	public typealias Wrapped = A
 
@@ -50,6 +53,9 @@ public struct Add<A: Addable>: Wrapper, Semigroup, Equatable {
 
 //: ------
 
+// sourcery: semigroup
+// sourcery: wrapper
+// sourcery: genericArbitraryTypes = "Int"
 public struct Multiply<A: Multipliable>: Wrapper, Semigroup, Equatable {
 	public typealias Wrapped = A
 
@@ -66,6 +72,9 @@ public struct Multiply<A: Multipliable>: Wrapper, Semigroup, Equatable {
 
 //: ------
 
+// sourcery: semigroup
+// sourcery: wrapper
+// sourcery: genericArbitraryTypes = "Int"
 public struct Max<A: ComparableToBottom>: Wrapper, Semigroup, Equatable {
 	public typealias Wrapped = A
 
@@ -82,6 +91,9 @@ public struct Max<A: ComparableToBottom>: Wrapper, Semigroup, Equatable {
 
 //: ------
 
+// sourcery: semigroup
+// sourcery: wrapper
+// sourcery: genericArbitraryTypes = "Int"
 public struct Min<A: ComparableToTop>: Wrapper, Semigroup, Equatable {
 	public typealias Wrapped = A
 
@@ -98,6 +110,8 @@ public struct Min<A: ComparableToTop>: Wrapper, Semigroup, Equatable {
 
 //: ------
 
+// sourcery: semigroup
+// sourcery: wrapper
 public struct And: Wrapper, Semigroup, Equatable, ExpressibleByBooleanLiteral {
 	public typealias Wrapped = Bool
 	public typealias BooleanLiteralType = Bool
@@ -119,6 +133,8 @@ public struct And: Wrapper, Semigroup, Equatable, ExpressibleByBooleanLiteral {
 
 //: ------
 
+// sourcery: semigroup
+// sourcery: wrapper
 public struct Or: Wrapper, Semigroup, Equatable, ExpressibleByBooleanLiteral {
 	public typealias Wrapped = Bool
 	public typealias BooleanLiteralType = Bool
@@ -140,6 +156,10 @@ public struct Or: Wrapper, Semigroup, Equatable, ExpressibleByBooleanLiteral {
 
 //: ------
 
+// sourcery: semigroup
+// sourcery: wrapper
+// sourcery: genericArbitraryTypes = "Int"
+// sourcery: requiredContext = "Int"
 public struct Endofunction<A: Equatable>: Wrapper, Semigroup, EquatableInContext {
 	public typealias Wrapped = (A) -> A
 	public typealias Context = A
@@ -165,6 +185,10 @@ public struct Endofunction<A: Equatable>: Wrapper, Semigroup, EquatableInContext
 
 //: ------
 
+// sourcery: semigroup
+// sourcery: wrapper
+// sourcery: genericArbitraryTypes = "Int,TestStructure"
+// sourcery: requiredContext = "Int"
 public struct FunctionS<A, S: Semigroup & Equatable>: Wrapper, Semigroup, EquatableInContext {
 	public typealias Wrapped = (A) -> S
 	public typealias Context = A
@@ -190,6 +214,7 @@ public struct FunctionS<A, S: Semigroup & Equatable>: Wrapper, Semigroup, Equata
 
 //: ------
 
+// sourcery: semigroup
 public enum Ordering: Semigroup {
 	case lowerThan
 	case equalTo

--- a/Sources/Abstract/Semigroup.swift
+++ b/Sources/Abstract/Semigroup.swift
@@ -34,8 +34,6 @@ Each type is tested for associativity in `AbstractTests.swift`, and for testing 
 
 //: ------
 
-// sourcery: semigroup
-// sourcery: wrapper
 // sourcery: genericArbitraryTypes = "Int"
 public struct Add<A: Addable>: Wrapper, Semigroup, Equatable {
 	public typealias Wrapped = A
@@ -53,8 +51,6 @@ public struct Add<A: Addable>: Wrapper, Semigroup, Equatable {
 
 //: ------
 
-// sourcery: semigroup
-// sourcery: wrapper
 // sourcery: genericArbitraryTypes = "Int"
 public struct Multiply<A: Multipliable>: Wrapper, Semigroup, Equatable {
 	public typealias Wrapped = A
@@ -72,8 +68,6 @@ public struct Multiply<A: Multipliable>: Wrapper, Semigroup, Equatable {
 
 //: ------
 
-// sourcery: semigroup
-// sourcery: wrapper
 // sourcery: genericArbitraryTypes = "Int"
 public struct Max<A: ComparableToBottom>: Wrapper, Semigroup, Equatable {
 	public typealias Wrapped = A
@@ -91,8 +85,6 @@ public struct Max<A: ComparableToBottom>: Wrapper, Semigroup, Equatable {
 
 //: ------
 
-// sourcery: semigroup
-// sourcery: wrapper
 // sourcery: genericArbitraryTypes = "Int"
 public struct Min<A: ComparableToTop>: Wrapper, Semigroup, Equatable {
 	public typealias Wrapped = A
@@ -110,8 +102,6 @@ public struct Min<A: ComparableToTop>: Wrapper, Semigroup, Equatable {
 
 //: ------
 
-// sourcery: semigroup
-// sourcery: wrapper
 public struct And: Wrapper, Semigroup, Equatable, ExpressibleByBooleanLiteral {
 	public typealias Wrapped = Bool
 	public typealias BooleanLiteralType = Bool
@@ -133,8 +123,6 @@ public struct And: Wrapper, Semigroup, Equatable, ExpressibleByBooleanLiteral {
 
 //: ------
 
-// sourcery: semigroup
-// sourcery: wrapper
 public struct Or: Wrapper, Semigroup, Equatable, ExpressibleByBooleanLiteral {
 	public typealias Wrapped = Bool
 	public typealias BooleanLiteralType = Bool
@@ -156,8 +144,6 @@ public struct Or: Wrapper, Semigroup, Equatable, ExpressibleByBooleanLiteral {
 
 //: ------
 
-// sourcery: semigroup
-// sourcery: wrapper
 // sourcery: genericArbitraryTypes = "Int"
 // sourcery: requiredContext = "Int"
 public struct Endofunction<A: Equatable>: Wrapper, Semigroup, EquatableInContext {
@@ -185,8 +171,6 @@ public struct Endofunction<A: Equatable>: Wrapper, Semigroup, EquatableInContext
 
 //: ------
 
-// sourcery: semigroup
-// sourcery: wrapper
 // sourcery: genericArbitraryTypes = "Int,TestStructure"
 // sourcery: requiredContext = "Int"
 public struct FunctionS<A, S: Semigroup & Equatable>: Wrapper, Semigroup, EquatableInContext {
@@ -214,7 +198,6 @@ public struct FunctionS<A, S: Semigroup & Equatable>: Wrapper, Semigroup, Equata
 
 //: ------
 
-// sourcery: semigroup
 public enum Ordering: Semigroup {
 	case lowerThan
 	case equalTo

--- a/Sources/Abstract/Semiring.swift
+++ b/Sources/Abstract/Semiring.swift
@@ -116,6 +116,8 @@ extension Bool: Semiring {
 
 //: ------
 
+// sourcery: genericArbitraryTypes = "Int,TestSemiring"
+// sourcery: requiredContext = "Int"
 public struct FunctionSR<A,SR: Semiring & Equatable>: Wrapper, Semiring, EquatableInContext where SR.Additive: Equatable, SR.Multiplicative: Equatable {
 	public typealias Wrapped = (A) -> SR
 	public typealias Additive = FunctionCM<A,SR.Additive>
@@ -159,6 +161,7 @@ public struct FunctionSR<A,SR: Semiring & Equatable>: Wrapper, Semiring, Equatab
 A Tropical semiring is just a fancy name for a (min, +)-semiring. This semiring is called tropical to honor the Brazillian mathematician, Imre Simon, who founded tropical mathematics.
  */
 
+// sourcery: genericArbitraryTypes = "Int"
 public struct Tropical<A: ComparableToTop & Addable & Equatable>: Wrapper, Semiring, Equatable {
     public typealias Wrapped = A
     public typealias Additive = Min<A>

--- a/Templates/Other/LinuxMain.stencil
+++ b/Templates/Other/LinuxMain.stencil
@@ -1,12 +1,10 @@
-// Generated using Sourcery 0.7.2 — https://github.com/krzysztofzablocki/Sourcery
-// DO NOT EDIT
-
-
 import XCTest
 @testable import AbstractTests
 
 XCTMain([
-	testCase(HomomorphismTests.allTests),
+{% for type in types.based.XCTestCase %}
+	testCase({{ type.name }}.allTests),
+{% endfor %}
 	testCase(BoundedSemilatticeTests.allTests),
 	testCase(CommutativeMonoidTests.allTests),
 	testCase(MonoidTests.allTests),

--- a/Templates/Other/LinuxMain.stencil
+++ b/Templates/Other/LinuxMain.stencil
@@ -5,10 +5,4 @@ XCTMain([
 {% for type in types.based.XCTestCase %}
 	testCase({{ type.name }}.allTests),
 {% endfor %}
-	testCase(BoundedSemilatticeTests.allTests),
-	testCase(CommutativeMonoidTests.allTests),
-	testCase(MonoidTests.allTests),
-	testCase(SemigroupTests.allTests),
-	testCase(SemiringTests.allTests),
-	testCase(WrapperTests.allTests)
 ])

--- a/Templates/Tests/BoundedSemilatticeTests.stencil
+++ b/Templates/Tests/BoundedSemilatticeTests.stencil
@@ -1,0 +1,28 @@
+import XCTest
+@testable import Abstract
+import SwiftCheck
+
+{% set protocolName %}BoundedSemilattice{% endset %}
+
+final class {{ protocolName }}Tests: XCTestCase {
+{% for type in types.implementing.BoundedSemilattice where not type.annotations.ignore == protocolName and not type.kind == "protocol" %}
+
+	func test{{ type.name }}() {
+{% if type.isGeneric %}
+		property("{{ type.name }} is a {{ protocolName }}") <- forAll { (a: {{ type.name }}Of<{{ type.annotations.genericArbitraryTypes }}>, b: {{ type.name }}Of<{{ type.annotations.genericArbitraryTypes }}>{% if type.annotations.requiredContext %}, context: {{ type.annotations.requiredContext }}{% else %}{% endif %}) in
+			Law{% if type.annotations.requiredContext %}InContext{% else %}{% endif %}<{{ type.name }}<{{ type.annotations.genericArbitraryTypes }}>>.isIdempotent(a.get,b.get){% if type.annotations.requiredContext %}(context){% else %}{% endif %}
+		}
+{% else %}
+		property("{{ type.name }} is a {{ protocolName }}") <- forAll { (a: {{ type.name }}, b: {{ type.name }}) in
+			Law<{{ type.name }}>.isIdempotent(a,b)
+		}
+{% endif %}
+	}
+{% endfor %}
+
+	static var allTests = [
+{% for type in types.implementing.BoundedSemilattice where not type.annotations.ignore == protocolName and not type.kind == "protocol" %}
+		("test{{ type.name }}",test{{ type.name }}),
+{% endfor %}
+	]
+}

--- a/Templates/Tests/CommutativeMonoidTests.stencil
+++ b/Templates/Tests/CommutativeMonoidTests.stencil
@@ -1,0 +1,28 @@
+import XCTest
+@testable import Abstract
+import SwiftCheck
+
+{% set protocolName %}CommutativeMonoid{% endset %}
+
+final class {{ protocolName }}Tests: XCTestCase {
+{% for type in types.implementing.CommutativeMonoid where not type.annotations.ignore == protocolName and not type.kind == "protocol" %}
+
+	func test{{ type.name }}() {
+{% if type.isGeneric %}
+		property("{{ type.name }} is a {{ protocolName }}") <- forAll { (a: {{ type.name }}Of<{{ type.annotations.genericArbitraryTypes }}>, b: {{ type.name }}Of<{{ type.annotations.genericArbitraryTypes }}>{% if type.annotations.requiredContext %}, context: {{ type.annotations.requiredContext }}{% else %}{% endif %}) in
+			Law{% if type.annotations.requiredContext %}InContext{% else %}{% endif %}<{{ type.name }}<{{ type.annotations.genericArbitraryTypes }}>>.isCommutative(a.get,b.get){% if type.annotations.requiredContext %}(context){% else %}{% endif %}
+		}
+{% else %}
+		property("{{ type.name }} is a {{ protocolName }}") <- forAll { (a: {{ type.name }}, b: {{ type.name }}) in
+			Law<{{ type.name }}>.isCommutative(a,b)
+		}
+{% endif %}
+	}
+{% endfor %}
+
+	static var allTests = [
+{% for type in types.implementing.CommutativeMonoid where not type.annotations.ignore == protocolName and not type.kind == "protocol" %}
+		("test{{ type.name }}",test{{ type.name }}),
+{% endfor %}
+	]
+}

--- a/Templates/Tests/MonoidTests.stencil
+++ b/Templates/Tests/MonoidTests.stencil
@@ -1,0 +1,28 @@
+import XCTest
+@testable import Abstract
+import SwiftCheck
+
+{% set protocolName %}Monoid{% endset %}
+
+final class {{ protocolName }}Tests: XCTestCase {
+{% for type in types.implementing.Monoid where not type.annotations.ignore == protocolName and not type.kind == "protocol" %}
+
+	func test{{ type.name }}() {
+{% if type.isGeneric %}
+	property("{{ type.name }} is a {{ protocolName }}") <- forAll { (a: {{ type.name }}Of<{{ type.annotations.genericArbitraryTypes }}>{% if type.annotations.requiredContext %}, context: {{ type.annotations.requiredContext }}{% else %}{% endif %}) in
+			Law{% if type.annotations.requiredContext %}InContext{% else %}{% endif %}<{{ type.name }}<{{ type.annotations.genericArbitraryTypes }}>>.isNeutralToEmpty(a.get){% if type.annotations.requiredContext %}(context){% else %}{% endif %}
+		}
+{% else %}
+		property("{{ type.name }} is a {{ protocolName }}") <- forAll { (a: {{ type.name }}) in
+			Law<{{ type.name }}>.isNeutralToEmpty(a)
+		}
+{% endif %}
+	}
+{% endfor %}
+
+	static var allTests = [
+{% for type in types.implementing.Monoid where not type.annotations.ignore == protocolName and not type.kind == "protocol" %}
+		("test{{ type.name }}",test{{ type.name }}),
+{% endfor %}
+	]
+}

--- a/Templates/Tests/SemigroupTests.stencil
+++ b/Templates/Tests/SemigroupTests.stencil
@@ -1,0 +1,26 @@
+import XCTest
+@testable import Abstract
+import SwiftCheck
+
+final class SemigroupTests: XCTestCase {
+{% for type in types.all|annotated:"semigroup" %}
+
+	func test{{ type.name }}() {
+{% if type.isGeneric %}
+		property("{{ type.name }} is a Semigroup") <- forAll { (a: {{ type.name }}Of<{{ type.annotations.genericArbitraryTypes }}>, b: {{ type.name }}Of<{{ type.annotations.genericArbitraryTypes }}>, c: {{ type.name }}Of<{{ type.annotations.genericArbitraryTypes }}>{% if type.annotations.requiredContext %}, context: {{ type.annotations.requiredContext }}{% else %}{% endif %}) in
+			Law{% if type.annotations.requiredContext %}InContext{% else %}{% endif %}<{{ type.name }}<{{ type.annotations.genericArbitraryTypes }}>>.isAssociative(a.get,b.get,c.get){% if type.annotations.requiredContext %}(context){% else %}{% endif %}
+		}
+{% else %}
+		property("{{ type.name }} is a Semigroup") <- forAll { (a: {{ type.name }}, b: {{ type.name }}, c: {{ type.name }}) in
+			Law<{{ type.name }}>.isAssociative(a,b,c)
+		}
+{% endif %}
+	}
+{% endfor %}
+
+	static var allTests = [
+{% for type in types.all|annotated:"semigroup" %}
+		("test{{ type.name }}",test{{ type.name }}),
+{% endfor %}
+	]
+}

--- a/Templates/Tests/SemigroupTests.stencil
+++ b/Templates/Tests/SemigroupTests.stencil
@@ -2,16 +2,18 @@ import XCTest
 @testable import Abstract
 import SwiftCheck
 
-final class SemigroupTests: XCTestCase {
-{% for type in types.all|annotated:"semigroup" %}
+{% set protocolName %}Semigroup{% endset %}
+
+final class {{ protocolName }}Tests: XCTestCase {
+{% for type in types.implementing.Semigroup where not type.annotations.ignore == protocolName and not type.kind == "protocol" %}
 
 	func test{{ type.name }}() {
 {% if type.isGeneric %}
-		property("{{ type.name }} is a Semigroup") <- forAll { (a: {{ type.name }}Of<{{ type.annotations.genericArbitraryTypes }}>, b: {{ type.name }}Of<{{ type.annotations.genericArbitraryTypes }}>, c: {{ type.name }}Of<{{ type.annotations.genericArbitraryTypes }}>{% if type.annotations.requiredContext %}, context: {{ type.annotations.requiredContext }}{% else %}{% endif %}) in
+		property("{{ type.name }} is a {{ protocolName }}") <- forAll { (a: {{ type.name }}Of<{{ type.annotations.genericArbitraryTypes }}>, b: {{ type.name }}Of<{{ type.annotations.genericArbitraryTypes }}>, c: {{ type.name }}Of<{{ type.annotations.genericArbitraryTypes }}>{% if type.annotations.requiredContext %}, context: {{ type.annotations.requiredContext }}{% else %}{% endif %}) in
 			Law{% if type.annotations.requiredContext %}InContext{% else %}{% endif %}<{{ type.name }}<{{ type.annotations.genericArbitraryTypes }}>>.isAssociative(a.get,b.get,c.get){% if type.annotations.requiredContext %}(context){% else %}{% endif %}
 		}
 {% else %}
-		property("{{ type.name }} is a Semigroup") <- forAll { (a: {{ type.name }}, b: {{ type.name }}, c: {{ type.name }}) in
+		property("{{ type.name }} is a {{ protocolName }}") <- forAll { (a: {{ type.name }}, b: {{ type.name }}, c: {{ type.name }}) in
 			Law<{{ type.name }}>.isAssociative(a,b,c)
 		}
 {% endif %}
@@ -19,7 +21,7 @@ final class SemigroupTests: XCTestCase {
 {% endfor %}
 
 	static var allTests = [
-{% for type in types.all|annotated:"semigroup" %}
+{% for type in types.implementing.Semigroup where not type.annotations.ignore == protocolName and not type.kind == "protocol" %}
 		("test{{ type.name }}",test{{ type.name }}),
 {% endfor %}
 	]

--- a/Templates/Tests/SemiringTests.stencil
+++ b/Templates/Tests/SemiringTests.stencil
@@ -1,0 +1,38 @@
+import XCTest
+@testable import Abstract
+import SwiftCheck
+
+{% set protocolName %}Semiring{% endset %}
+
+final class {{ protocolName }}Tests: XCTestCase {
+{% for type in types.implementing.Semiring where not type.annotations.ignore == protocolName and not type.kind == "protocol" %}
+
+	func test{{ type.name }}() {
+{% if type.isGeneric %}
+		property("{{ type.name }} is a {{ protocolName }}: Distributive") <- forAll { (a: {{ type.name }}Of<{{ type.annotations.genericArbitraryTypes }}>, b: {{ type.name }}Of<{{ type.annotations.genericArbitraryTypes }}>, c: {{ type.name }}Of<{{ type.annotations.genericArbitraryTypes }}>{% if type.annotations.requiredContext %}, context: {{ type.annotations.requiredContext }}{% else %}{% endif %}) in
+			Law{% if type.annotations.requiredContext %}InContext{% else %}{% endif %}<{{ type.name }}<{{ type.annotations.genericArbitraryTypes }}>>.multiplicationIsDistributiveOverAddition(a.get,b.get,c.get){% if type.annotations.requiredContext %}(context){% else %}{% endif %}
+		}
+{% else %}
+		property("{{ type.name }} is a {{ protocolName }}: Distributive") <- forAll { (a: {{ type.name }}, b: {{ type.name }}, c: {{ type.name }}) in
+			Law<{{ type.name }}>.multiplicationIsDistributiveOverAddition(a,b,c)
+		}
+{% endif %}
+
+{% if type.isGeneric %}
+		property("{{ type.name }} is a {{ protocolName }}: Annihilation") <- forAll { (a: {{ type.name }}Of<{{ type.annotations.genericArbitraryTypes }}>{% if type.annotations.requiredContext %}, context: {{ type.annotations.requiredContext }}{% else %}{% endif %}) in
+			Law{% if type.annotations.requiredContext %}InContext{% else %}{% endif %}<{{ type.name }}<{{ type.annotations.genericArbitraryTypes }}>>.zeroAnnihiliatesTheMultiplicative(a.get){% if type.annotations.requiredContext %}(context){% else %}{% endif %}
+		}
+{% else %}
+		property("{{ type.name }} is a {{ protocolName }}: Annihilation") <- forAll { (a: {{ type.name }}) in
+			Law<{{ type.name }}>.zeroAnnihiliatesTheMultiplicative(a)
+		}
+{% endif %}
+	}
+{% endfor %}
+
+	static var allTests = [
+{% for type in types.implementing.Semiring where not type.annotations.ignore == protocolName and not type.kind == "protocol" %}
+		("test{{ type.name }}",test{{ type.name }}),
+{% endfor %}
+	]
+}

--- a/Templates/Tests/WrapperTests.stencil
+++ b/Templates/Tests/WrapperTests.stencil
@@ -1,0 +1,26 @@
+import XCTest
+@testable import Abstract
+import SwiftCheck
+
+final class WrapperTests: XCTestCase {
+{% for type in types.all|annotated:"wrapper" %}
+
+	func test{{ type.name }}() {
+{% if type.isGeneric %}
+		property("{{ type.name }} is a well-behaved Wrapper") <- forAll { (a: {{ type.name }}Of<{{ type.annotations.genericArbitraryTypes }}>{% if type.annotations.requiredContext %}, context: {{ type.annotations.requiredContext }}{% else %}{% endif %}) in
+			Law{% if type.annotations.requiredContext %}InContext{% else %}{% endif %}<{{ type.name }}<{{ type.annotations.genericArbitraryTypes }}>>.isWellBehavedWrapper(a.get){% if type.annotations.requiredContext %}(context){% else %}{% endif %}
+		}
+{% else %}
+		property("{{ type.name }} is a well-behaved Wrapper") <- forAll { (a: {{ type.name }}) in
+			Law<{{ type.name }}>.isWellBehavedWrapper(a)
+		}
+{% endif %}
+	}
+{% endfor %}
+
+	static var allTests = [
+{% for type in types.all|annotated:"wrapper" %}
+		("test{{ type.name }}",test{{ type.name }}),
+{% endfor %}
+	]
+}

--- a/Templates/Tests/WrapperTests.stencil
+++ b/Templates/Tests/WrapperTests.stencil
@@ -2,8 +2,10 @@ import XCTest
 @testable import Abstract
 import SwiftCheck
 
+{% set protocolName %}Wrapper{% endset %}
+
 final class WrapperTests: XCTestCase {
-{% for type in types.all|annotated:"wrapper" %}
+{% for type in types.implementing.Wrapper where not type.annotations.ignore == protocolName and not type.kind == "protocol" %}
 
 	func test{{ type.name }}() {
 {% if type.isGeneric %}
@@ -19,7 +21,7 @@ final class WrapperTests: XCTestCase {
 {% endfor %}
 
 	static var allTests = [
-{% for type in types.all|annotated:"wrapper" %}
+{% for type in types.implementing.Wrapper where not type.annotations.ignore == protocolName and not type.kind == "protocol" %}
 		("test{{ type.name }}",test{{ type.name }}),
 {% endfor %}
 	]

--- a/Tests/AbstractTests/AbstractTests.swift
+++ b/Tests/AbstractTests/AbstractTests.swift
@@ -3,96 +3,6 @@ import XCTest
 import SwiftCheck
 
 final class AbstractTests: XCTestCase {
-	func testMonoid() {
-		property("Add is a Monoid") <- forAll { (a: AddOf<Int>) in
-			Law<Add<Int>>.isNeutralToEmpty(a.get)
-		}
-		
-		property("Multiply is a Monoid") <- forAll { (a: MultiplyOf<Int>) in
-			Law<Multiply<Int>>.isNeutralToEmpty(a.get)
-		}
-
-		property("Max is a Monoid") <- forAll { (a: MaxOf<Int>) in
-			Law<Max<Int>>.isNeutralToEmpty(a.get)
-		}
-
-		property("Min is a Monoid") <- forAll { (a: MinOf<Int>) in
-			Law<Min<Int>>.isNeutralToEmpty(a.get)
-		}
-		
-		property("And is a Monoid") <- forAll { (a: And) in
-			Law<And>.isNeutralToEmpty(a)
-		}
-
-		property("Or is a Monoid") <- forAll { (a: Or) in
-			Law<Or>.isNeutralToEmpty(a)
-		}
-
-		property("Endofunction is a Monoid") <- forAll { (a: EndofunctionOf<Int>, context: Int) in
-			LawInContext<Endofunction<Int>>.isNeutralToEmpty(a.get)(context)
-		}
-
-		property("FunctionM is a Monoid") <- forAll { (a: FunctionMOf<Int,TestStructure>, context: Int) in
-			LawInContext<FunctionM<Int,TestStructure>>.isNeutralToEmpty(a.get)(context)
-		}
-		
-		property("Ordering is a Monoid") <- forAll { (a: Ordering) in
-			Law<Ordering>.isNeutralToEmpty(a)
-		}
-	}
-	
-	func testCommutativeMonoid() {
-		property("Add is a Commutative Monoid") <- forAll { (a: AddOf<Int>, b: AddOf<Int>) in
-			Law<Add<Int>>.isCommutative(a.get,b.get)
-		}
-
-		property("Multiply is a Commutative Monoid") <- forAll { (a: MultiplyOf<Int>, b: MultiplyOf<Int>) in
-			Law<Multiply<Int>>.isCommutative(a.get,b.get)
-		}
-
-		property("Max is a Commutative Monoid") <- forAll { (a: MaxOf<Int>, b: MaxOf<Int>) in
-			Law<Max<Int>>.isCommutative(a.get,b.get)
-		}
-
-		property("Min is a Commutative Monoid") <- forAll { (a: MinOf<Int>, b: MinOf<Int>) in
-			Law<Min<Int>>.isCommutative(a.get,b.get)
-		}
-
-		property("And is a Commutative Monoid") <- forAll { (a: And, b: And) in
-			Law<And>.isCommutative(a,b)
-		}
-
-		property("Or is a Commutative Monoid") <- forAll { (a: Or, b: Or) in
-			Law<Or>.isCommutative(a,b)
-		}
-
-		property("FunctionCM is a Commutative Monoid") <- forAll { (a: FunctionCMOf<Int,TestStructure>, b: FunctionCMOf<Int,TestStructure>, context: Int) in
-			LawInContext<FunctionCM<Int,TestStructure>>.isCommutative(a.get,b.get)(context)
-		}
-	}
-	
-	func testBoundedSemilattice() {
-		property("Max is a Bounded Semilattice") <- forAll { (a: MaxOf<Int>, b: MaxOf<Int>) in
-			Law<Max<Int>>.isIdempotent(a.get,b.get)
-		}
-		
-		property("Min is a Bounded Semilattice") <- forAll { (a: MinOf<Int>, b: MinOf<Int>) in
-			Law<Min<Int>>.isIdempotent(a.get,b.get)
-		}
-		
-		property("And is a Bounded Semilattice") <- forAll { (a: And, b: And) in
-			Law<And>.isIdempotent(a,b)
-		}
-
-		property("Or is a Bounded Semilattice") <- forAll { (a: Or, b: Or) in
-			Law<Or>.isIdempotent(a,b)
-		}
-
-		property("FunctionBS is a Bounded Semilattice") <- forAll { (a: FunctionBSOf<Int,TestStructure>, b: FunctionBSOf<Int,TestStructure>, context: Int) in
-			LawInContext<FunctionBS<Int,TestStructure>>.isIdempotent(a.get,b.get)(context)
-		}
-	}
-
 	func testSemiring() {
 		property("Bool is a Semiring: Distributive") <- forAll { (a: Bool, b: Bool, c: Bool) in
 			Law<Bool>.multiplicationIsDistributiveOverAddition(a, b, c)
@@ -130,9 +40,6 @@ final class AbstractTests: XCTestCase {
 	}
 	
 	static var allTests = [
-		("testMonoid", testMonoid),
-		("testCommutativeMonoid",testCommutativeMonoid),
-		("testBoundedSemilattice",testBoundedSemilattice),
 		("testSemiring",testSemiring),
 		("testHomomorphism",testHomomorphism)
 	]

--- a/Tests/AbstractTests/AbstractTests.swift
+++ b/Tests/AbstractTests/AbstractTests.swift
@@ -3,32 +3,6 @@ import XCTest
 import SwiftCheck
 
 final class AbstractTests: XCTestCase {
-	func testSemiring() {
-		property("Bool is a Semiring: Distributive") <- forAll { (a: Bool, b: Bool, c: Bool) in
-			Law<Bool>.multiplicationIsDistributiveOverAddition(a, b, c)
-		}
-
-		property("Bool is a Semiring: Annihilation") <- forAll { (a: Bool) in
-			Law<Bool>.zeroAnnihiliatesTheMultiplicative(a)
-		}
-
-		property("FunctionSR is a Semiring: Distributive") <- forAll { (a: FunctionSROf<Int,TestSemiring>, b: FunctionSROf<Int,TestSemiring>, c: FunctionSROf<Int,TestSemiring>, context: Int) in
-			LawInContext<FunctionSR<Int,TestSemiring>>.multiplicationIsDistributiveOverAddition(a.get, b.get, c.get)(context)
-		}
-
-		property("FunctionSR is a Semiring: Annihilation") <- forAll { (a: FunctionSROf<Int,TestSemiring>, context: Int) in
-			LawInContext<FunctionSR<Int,TestSemiring>>.zeroAnnihiliatesTheMultiplicative(a.get)(context)
-		}
-        
-        property("Tropical is a Semiring: Distributive") <- forAll { (a: TropicalOf<Int>, b: TropicalOf<Int>, c: TropicalOf<Int>) in
-            Law<Tropical<Int>>.multiplicationIsDistributiveOverAddition(a.get, b.get, c.get)
-        }
-        
-        property("Tropical is a Semiring: Annihilation") <- forAll { (a: TropicalOf<Int>) in
-            Law<Tropical<Int>>.zeroAnnihiliatesTheMultiplicative(a.get)
-        }
-	}
-
 	func testHomomorphism() {
 		property("Ordering.reversed is a Homomorphism") <- forAll { (a: Ordering, b: Ordering) in
 			Law<Ordering>.isHomomorphism({ $0.reversed }, a, b)

--- a/Tests/AbstractTests/AbstractTests.swift
+++ b/Tests/AbstractTests/AbstractTests.swift
@@ -3,90 +3,6 @@ import XCTest
 import SwiftCheck
 
 final class AbstractTests: XCTestCase {
-	func testWrapper() {
-		property("Add is a well-behaved Wrapper") <- forAll { (a: AddOf<Int>) in
-			Law<Add<Int>>.isWellBehavedWrapper(a.get)
-		}
-
-		property("Multiply is a well-behaved Wrapper") <- forAll { (a: MultiplyOf<Int>) in
-			Law<Multiply<Int>>.isWellBehavedWrapper(a.get)
-		}
-
-		property("Max is a well-behaved Wrapper") <- forAll { (a: MaxOf<Int>) in
-			Law<Max<Int>>.isWellBehavedWrapper(a.get)
-		}
-
-		property("Min is a well-behaved Wrapper") <- forAll { (a: MinOf<Int>) in
-			Law<Min<Int>>.isWellBehavedWrapper(a.get)
-		}
-
-		property("And is a well-behaved Wrapper") <- forAll { (a: And) in
-			Law<And>.isWellBehavedWrapper(a)
-		}
-
-		property("Or is a well-behaved Wrapper") <- forAll { (a: Or) in
-			Law<Or>.isWellBehavedWrapper(a)
-		}
-
-		property("Endofunction is a well-behaved Wrapper") <- forAll { (a: EndofunctionOf<Int>, context: Int) in
-			LawInContext<Endofunction<Int>>.isWellBehavedWrapper(a.get)(context)
-		}
-
-		property("FunctionS is a well-behaved Wrapper") <- forAll { (a: FunctionSOf<Int,TestStructure>, context: Int) in
-			LawInContext<FunctionS<Int,TestStructure>>.isWellBehavedWrapper(a.get)(context)
-		}
-
-		property("FunctionM is a well-behaved Wrapper") <- forAll { (a: FunctionMOf<Int,TestStructure>, context: Int) in
-			LawInContext<FunctionM<Int,TestStructure>>.isWellBehavedWrapper(a.get)(context)
-		}
-
-		property("FunctionCM is a well-behaved Wrapper") <- forAll { (a: FunctionCMOf<Int,TestStructure>, context: Int) in
-			LawInContext<FunctionCM<Int,TestStructure>>.isWellBehavedWrapper(a.get)(context)
-		}
-
-		property("FunctionBS is a well-behaved Wrapper") <- forAll { (a: FunctionBSOf<Int,TestStructure>, context: Int) in
-			LawInContext<FunctionBS<Int,TestStructure>>.isWellBehavedWrapper(a.get)(context)
-		}
-	}
-
-	func testSemigroup() {
-		property("Add is a Semigroup") <- forAll { (a: AddOf<Int>, b: AddOf<Int>, c: AddOf<Int>) in
-			Law<Add<Int>>.isAssociative(a.get,b.get,c.get)
-		}
-		
-		property("Multiply is a Semigroup") <- forAll { (a: MultiplyOf<Int>, b: MultiplyOf<Int>, c: MultiplyOf<Int>) in
-			Law<Multiply<Int>>.isAssociative(a.get,b.get,c.get)
-		}
-		
-		property("Max is a Semigroup") <- forAll { (a: MaxOf<Int>, b: MaxOf<Int>, c: MaxOf<Int>) in
-			Law<Max<Int>>.isAssociative(a.get,b.get,c.get)
-		}
-
-		property("Min is a Semigroup") <- forAll { (a: MinOf<Int>, b: MinOf<Int>, c: MinOf<Int>) in
-			Law<Min<Int>>.isAssociative(a.get,b.get,c.get)
-		}
-
-		property("And is a Semigroup") <- forAll { (a: And, b: And, c: And) in
-			Law<And>.isAssociative(a,b,c)
-		}
-
-		property("Or is a Semigroup") <- forAll { (a: Or, b: Or, c: Or) in
-			Law<Or>.isAssociative(a,b,c)
-		}
-
-		property("Endofunction is a Semigroup") <- forAll { (a: EndofunctionOf<Int>, b: EndofunctionOf<Int>, c: EndofunctionOf<Int>, context: Int) in
-			LawInContext<Endofunction<Int>>.isAssociative(a.get, b.get, c.get)(context)
-		}
-		
-		property("FunctionS is a Semigroup") <- forAll { (a: FunctionSOf<Int,TestStructure>, b: FunctionSOf<Int,TestStructure>, c: FunctionSOf<Int,TestStructure>, context: Int) in
-			LawInContext<FunctionS<Int,TestStructure>>.isAssociative(a.get, b.get, c.get)(context)
-		}
-		
-		property("Ordering is a Semigroup") <- forAll { (a: Ordering, b: Ordering, c: Ordering) in
-			Law<Ordering>.isAssociative(a, b, c)
-		}
-	}
-	
 	func testMonoid() {
 		property("Add is a Monoid") <- forAll { (a: AddOf<Int>) in
 			Law<Add<Int>>.isNeutralToEmpty(a.get)
@@ -214,8 +130,6 @@ final class AbstractTests: XCTestCase {
 	}
 	
 	static var allTests = [
-		("testWrapper", testWrapper),
-		("testSemigroup", testSemigroup),
 		("testMonoid", testMonoid),
 		("testCommutativeMonoid",testCommutativeMonoid),
 		("testBoundedSemilattice",testBoundedSemilattice),

--- a/Tests/AbstractTests/BoundedSemilatticeTests.generated.swift
+++ b/Tests/AbstractTests/BoundedSemilatticeTests.generated.swift
@@ -1,0 +1,48 @@
+// Generated using Sourcery 0.7.2 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import XCTest
+@testable import Abstract
+import SwiftCheck
+
+
+final class BoundedSemilatticeTests: XCTestCase {
+
+	func testAnd() {
+		property("And is a BoundedSemilattice") <- forAll { (a: And, b: And) in
+			Law<And>.isIdempotent(a,b)
+		}
+	}
+
+	func testFunctionBS() {
+		property("FunctionBS is a BoundedSemilattice") <- forAll { (a: FunctionBSOf<Int,TestStructure>, b: FunctionBSOf<Int,TestStructure>, context: Int) in
+			LawInContext<FunctionBS<Int,TestStructure>>.isIdempotent(a.get,b.get)(context)
+		}
+	}
+
+	func testMax() {
+		property("Max is a BoundedSemilattice") <- forAll { (a: MaxOf<Int>, b: MaxOf<Int>) in
+			Law<Max<Int>>.isIdempotent(a.get,b.get)
+		}
+	}
+
+	func testMin() {
+		property("Min is a BoundedSemilattice") <- forAll { (a: MinOf<Int>, b: MinOf<Int>) in
+			Law<Min<Int>>.isIdempotent(a.get,b.get)
+		}
+	}
+
+	func testOr() {
+		property("Or is a BoundedSemilattice") <- forAll { (a: Or, b: Or) in
+			Law<Or>.isIdempotent(a,b)
+		}
+	}
+
+	static var allTests = [
+		("testAnd",testAnd),
+		("testFunctionBS",testFunctionBS),
+		("testMax",testMax),
+		("testMin",testMin),
+		("testOr",testOr),
+	]
+}

--- a/Tests/AbstractTests/CommutativeMonoidTests.generated.swift
+++ b/Tests/AbstractTests/CommutativeMonoidTests.generated.swift
@@ -1,0 +1,69 @@
+// Generated using Sourcery 0.7.2 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import XCTest
+@testable import Abstract
+import SwiftCheck
+
+
+final class CommutativeMonoidTests: XCTestCase {
+
+	func testAdd() {
+		property("Add is a CommutativeMonoid") <- forAll { (a: AddOf<Int>, b: AddOf<Int>) in
+			Law<Add<Int>>.isCommutative(a.get,b.get)
+		}
+	}
+
+	func testAnd() {
+		property("And is a CommutativeMonoid") <- forAll { (a: And, b: And) in
+			Law<And>.isCommutative(a,b)
+		}
+	}
+
+	func testFunctionBS() {
+		property("FunctionBS is a CommutativeMonoid") <- forAll { (a: FunctionBSOf<Int,TestStructure>, b: FunctionBSOf<Int,TestStructure>, context: Int) in
+			LawInContext<FunctionBS<Int,TestStructure>>.isCommutative(a.get,b.get)(context)
+		}
+	}
+
+	func testFunctionCM() {
+		property("FunctionCM is a CommutativeMonoid") <- forAll { (a: FunctionCMOf<Int,TestStructure>, b: FunctionCMOf<Int,TestStructure>, context: Int) in
+			LawInContext<FunctionCM<Int,TestStructure>>.isCommutative(a.get,b.get)(context)
+		}
+	}
+
+	func testMax() {
+		property("Max is a CommutativeMonoid") <- forAll { (a: MaxOf<Int>, b: MaxOf<Int>) in
+			Law<Max<Int>>.isCommutative(a.get,b.get)
+		}
+	}
+
+	func testMin() {
+		property("Min is a CommutativeMonoid") <- forAll { (a: MinOf<Int>, b: MinOf<Int>) in
+			Law<Min<Int>>.isCommutative(a.get,b.get)
+		}
+	}
+
+	func testMultiply() {
+		property("Multiply is a CommutativeMonoid") <- forAll { (a: MultiplyOf<Int>, b: MultiplyOf<Int>) in
+			Law<Multiply<Int>>.isCommutative(a.get,b.get)
+		}
+	}
+
+	func testOr() {
+		property("Or is a CommutativeMonoid") <- forAll { (a: Or, b: Or) in
+			Law<Or>.isCommutative(a,b)
+		}
+	}
+
+	static var allTests = [
+		("testAdd",testAdd),
+		("testAnd",testAnd),
+		("testFunctionBS",testFunctionBS),
+		("testFunctionCM",testFunctionCM),
+		("testMax",testMax),
+		("testMin",testMin),
+		("testMultiply",testMultiply),
+		("testOr",testOr),
+	]
+}

--- a/Tests/AbstractTests/HomomorphismTests.swift
+++ b/Tests/AbstractTests/HomomorphismTests.swift
@@ -2,19 +2,22 @@ import XCTest
 @testable import Abstract
 import SwiftCheck
 
-final class AbstractTests: XCTestCase {
-	func testHomomorphism() {
+final class HomomorphismTests: XCTestCase {
+
+	func testOrderingReversed() {
 		property("Ordering.reversed is a Homomorphism") <- forAll { (a: Ordering, b: Ordering) in
 			Law<Ordering>.isHomomorphism({ $0.reversed }, a, b)
 		}
-		
+	}
+
+	func testComparisonReversed() {
 		property("Comparison.reversed is a Homomorphism") <- forAll { (a: FunctionMOf<TestProduct,Ordering>, b: FunctionMOf<TestProduct,Ordering>, context: TestProduct) in
 			LawInContext<Comparison<Int>>.isHomomorphism({ $0.reversed }, Comparison<Int> { a.get.call(TestProduct.init($0)) }, Comparison<Int> { b.get.call(TestProduct.init($0)) })(context.unwrap)
 		}
 	}
 	
 	static var allTests = [
-		("testSemiring",testSemiring),
-		("testHomomorphism",testHomomorphism)
+		("testOrderingReversed",testOrderingReversed),
+		("testComparisonReversed",testComparisonReversed)
 	]
 }

--- a/Tests/AbstractTests/MonoidTests.generated.swift
+++ b/Tests/AbstractTests/MonoidTests.generated.swift
@@ -1,0 +1,90 @@
+// Generated using Sourcery 0.7.2 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import XCTest
+@testable import Abstract
+import SwiftCheck
+
+
+final class MonoidTests: XCTestCase {
+
+	func testAdd() {
+	property("Add is a Monoid") <- forAll { (a: AddOf<Int>) in
+			Law<Add<Int>>.isNeutralToEmpty(a.get)
+		}
+	}
+
+	func testAnd() {
+		property("And is a Monoid") <- forAll { (a: And) in
+			Law<And>.isNeutralToEmpty(a)
+		}
+	}
+
+	func testEndofunction() {
+	property("Endofunction is a Monoid") <- forAll { (a: EndofunctionOf<Int>, context: Int) in
+			LawInContext<Endofunction<Int>>.isNeutralToEmpty(a.get)(context)
+		}
+	}
+
+	func testFunctionBS() {
+	property("FunctionBS is a Monoid") <- forAll { (a: FunctionBSOf<Int,TestStructure>, context: Int) in
+			LawInContext<FunctionBS<Int,TestStructure>>.isNeutralToEmpty(a.get)(context)
+		}
+	}
+
+	func testFunctionCM() {
+	property("FunctionCM is a Monoid") <- forAll { (a: FunctionCMOf<Int,TestStructure>, context: Int) in
+			LawInContext<FunctionCM<Int,TestStructure>>.isNeutralToEmpty(a.get)(context)
+		}
+	}
+
+	func testFunctionM() {
+	property("FunctionM is a Monoid") <- forAll { (a: FunctionMOf<Int,TestStructure>, context: Int) in
+			LawInContext<FunctionM<Int,TestStructure>>.isNeutralToEmpty(a.get)(context)
+		}
+	}
+
+	func testMax() {
+	property("Max is a Monoid") <- forAll { (a: MaxOf<Int>) in
+			Law<Max<Int>>.isNeutralToEmpty(a.get)
+		}
+	}
+
+	func testMin() {
+	property("Min is a Monoid") <- forAll { (a: MinOf<Int>) in
+			Law<Min<Int>>.isNeutralToEmpty(a.get)
+		}
+	}
+
+	func testMultiply() {
+	property("Multiply is a Monoid") <- forAll { (a: MultiplyOf<Int>) in
+			Law<Multiply<Int>>.isNeutralToEmpty(a.get)
+		}
+	}
+
+	func testOr() {
+		property("Or is a Monoid") <- forAll { (a: Or) in
+			Law<Or>.isNeutralToEmpty(a)
+		}
+	}
+
+	func testOrdering() {
+		property("Ordering is a Monoid") <- forAll { (a: Ordering) in
+			Law<Ordering>.isNeutralToEmpty(a)
+		}
+	}
+
+	static var allTests = [
+		("testAdd",testAdd),
+		("testAnd",testAnd),
+		("testEndofunction",testEndofunction),
+		("testFunctionBS",testFunctionBS),
+		("testFunctionCM",testFunctionCM),
+		("testFunctionM",testFunctionM),
+		("testMax",testMax),
+		("testMin",testMin),
+		("testMultiply",testMultiply),
+		("testOr",testOr),
+		("testOrdering",testOrdering),
+	]
+}

--- a/Tests/AbstractTests/SemigroupTests.generated.swift
+++ b/Tests/AbstractTests/SemigroupTests.generated.swift
@@ -5,6 +5,7 @@ import XCTest
 @testable import Abstract
 import SwiftCheck
 
+
 final class SemigroupTests: XCTestCase {
 
 	func testAdd() {
@@ -22,6 +23,24 @@ final class SemigroupTests: XCTestCase {
 	func testEndofunction() {
 		property("Endofunction is a Semigroup") <- forAll { (a: EndofunctionOf<Int>, b: EndofunctionOf<Int>, c: EndofunctionOf<Int>, context: Int) in
 			LawInContext<Endofunction<Int>>.isAssociative(a.get,b.get,c.get)(context)
+		}
+	}
+
+	func testFunctionBS() {
+		property("FunctionBS is a Semigroup") <- forAll { (a: FunctionBSOf<Int,TestStructure>, b: FunctionBSOf<Int,TestStructure>, c: FunctionBSOf<Int,TestStructure>, context: Int) in
+			LawInContext<FunctionBS<Int,TestStructure>>.isAssociative(a.get,b.get,c.get)(context)
+		}
+	}
+
+	func testFunctionCM() {
+		property("FunctionCM is a Semigroup") <- forAll { (a: FunctionCMOf<Int,TestStructure>, b: FunctionCMOf<Int,TestStructure>, c: FunctionCMOf<Int,TestStructure>, context: Int) in
+			LawInContext<FunctionCM<Int,TestStructure>>.isAssociative(a.get,b.get,c.get)(context)
+		}
+	}
+
+	func testFunctionM() {
+		property("FunctionM is a Semigroup") <- forAll { (a: FunctionMOf<Int,TestStructure>, b: FunctionMOf<Int,TestStructure>, c: FunctionMOf<Int,TestStructure>, context: Int) in
+			LawInContext<FunctionM<Int,TestStructure>>.isAssociative(a.get,b.get,c.get)(context)
 		}
 	}
 
@@ -65,6 +84,9 @@ final class SemigroupTests: XCTestCase {
 		("testAdd",testAdd),
 		("testAnd",testAnd),
 		("testEndofunction",testEndofunction),
+		("testFunctionBS",testFunctionBS),
+		("testFunctionCM",testFunctionCM),
+		("testFunctionM",testFunctionM),
 		("testFunctionS",testFunctionS),
 		("testMax",testMax),
 		("testMin",testMin),

--- a/Tests/AbstractTests/SemigroupTests.generated.swift
+++ b/Tests/AbstractTests/SemigroupTests.generated.swift
@@ -1,0 +1,75 @@
+// Generated using Sourcery 0.7.2 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import XCTest
+@testable import Abstract
+import SwiftCheck
+
+final class SemigroupTests: XCTestCase {
+
+	func testAdd() {
+		property("Add is a Semigroup") <- forAll { (a: AddOf<Int>, b: AddOf<Int>, c: AddOf<Int>) in
+			Law<Add<Int>>.isAssociative(a.get,b.get,c.get)
+		}
+	}
+
+	func testAnd() {
+		property("And is a Semigroup") <- forAll { (a: And, b: And, c: And) in
+			Law<And>.isAssociative(a,b,c)
+		}
+	}
+
+	func testEndofunction() {
+		property("Endofunction is a Semigroup") <- forAll { (a: EndofunctionOf<Int>, b: EndofunctionOf<Int>, c: EndofunctionOf<Int>, context: Int) in
+			LawInContext<Endofunction<Int>>.isAssociative(a.get,b.get,c.get)(context)
+		}
+	}
+
+	func testFunctionS() {
+		property("FunctionS is a Semigroup") <- forAll { (a: FunctionSOf<Int,TestStructure>, b: FunctionSOf<Int,TestStructure>, c: FunctionSOf<Int,TestStructure>, context: Int) in
+			LawInContext<FunctionS<Int,TestStructure>>.isAssociative(a.get,b.get,c.get)(context)
+		}
+	}
+
+	func testMax() {
+		property("Max is a Semigroup") <- forAll { (a: MaxOf<Int>, b: MaxOf<Int>, c: MaxOf<Int>) in
+			Law<Max<Int>>.isAssociative(a.get,b.get,c.get)
+		}
+	}
+
+	func testMin() {
+		property("Min is a Semigroup") <- forAll { (a: MinOf<Int>, b: MinOf<Int>, c: MinOf<Int>) in
+			Law<Min<Int>>.isAssociative(a.get,b.get,c.get)
+		}
+	}
+
+	func testMultiply() {
+		property("Multiply is a Semigroup") <- forAll { (a: MultiplyOf<Int>, b: MultiplyOf<Int>, c: MultiplyOf<Int>) in
+			Law<Multiply<Int>>.isAssociative(a.get,b.get,c.get)
+		}
+	}
+
+	func testOr() {
+		property("Or is a Semigroup") <- forAll { (a: Or, b: Or, c: Or) in
+			Law<Or>.isAssociative(a,b,c)
+		}
+	}
+
+	func testOrdering() {
+		property("Ordering is a Semigroup") <- forAll { (a: Ordering, b: Ordering, c: Ordering) in
+			Law<Ordering>.isAssociative(a,b,c)
+		}
+	}
+
+	static var allTests = [
+		("testAdd",testAdd),
+		("testAnd",testAnd),
+		("testEndofunction",testEndofunction),
+		("testFunctionS",testFunctionS),
+		("testMax",testMax),
+		("testMin",testMin),
+		("testMultiply",testMultiply),
+		("testOr",testOr),
+		("testOrdering",testOrdering),
+	]
+}

--- a/Tests/AbstractTests/SemiringTests.generated.swift
+++ b/Tests/AbstractTests/SemiringTests.generated.swift
@@ -1,0 +1,46 @@
+// Generated using Sourcery 0.7.2 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import XCTest
+@testable import Abstract
+import SwiftCheck
+
+
+final class SemiringTests: XCTestCase {
+
+	func testBool() {
+		property("Bool is a Semiring: Distributive") <- forAll { (a: Bool, b: Bool, c: Bool) in
+			Law<Bool>.multiplicationIsDistributiveOverAddition(a,b,c)
+		}
+
+		property("Bool is a Semiring: Annihilation") <- forAll { (a: Bool) in
+			Law<Bool>.zeroAnnihiliatesTheMultiplicative(a)
+		}
+	}
+
+	func testFunctionSR() {
+		property("FunctionSR is a Semiring: Distributive") <- forAll { (a: FunctionSROf<Int,TestSemiring>, b: FunctionSROf<Int,TestSemiring>, c: FunctionSROf<Int,TestSemiring>, context: Int) in
+			LawInContext<FunctionSR<Int,TestSemiring>>.multiplicationIsDistributiveOverAddition(a.get,b.get,c.get)(context)
+		}
+
+		property("FunctionSR is a Semiring: Annihilation") <- forAll { (a: FunctionSROf<Int,TestSemiring>, context: Int) in
+			LawInContext<FunctionSR<Int,TestSemiring>>.zeroAnnihiliatesTheMultiplicative(a.get)(context)
+		}
+	}
+
+	func testTropical() {
+		property("Tropical is a Semiring: Distributive") <- forAll { (a: TropicalOf<Int>, b: TropicalOf<Int>, c: TropicalOf<Int>) in
+			Law<Tropical<Int>>.multiplicationIsDistributiveOverAddition(a.get,b.get,c.get)
+		}
+
+		property("Tropical is a Semiring: Annihilation") <- forAll { (a: TropicalOf<Int>) in
+			Law<Tropical<Int>>.zeroAnnihiliatesTheMultiplicative(a.get)
+		}
+	}
+
+	static var allTests = [
+		("testBool",testBool),
+		("testFunctionSR",testFunctionSR),
+		("testTropical",testTropical),
+	]
+}

--- a/Tests/AbstractTests/WrapperTests.generated.swift
+++ b/Tests/AbstractTests/WrapperTests.generated.swift
@@ -5,6 +5,7 @@ import XCTest
 @testable import Abstract
 import SwiftCheck
 
+
 final class WrapperTests: XCTestCase {
 
 	func testAdd() {
@@ -25,9 +26,33 @@ final class WrapperTests: XCTestCase {
 		}
 	}
 
+	func testFunctionBS() {
+		property("FunctionBS is a well-behaved Wrapper") <- forAll { (a: FunctionBSOf<Int,TestStructure>, context: Int) in
+			LawInContext<FunctionBS<Int,TestStructure>>.isWellBehavedWrapper(a.get)(context)
+		}
+	}
+
+	func testFunctionCM() {
+		property("FunctionCM is a well-behaved Wrapper") <- forAll { (a: FunctionCMOf<Int,TestStructure>, context: Int) in
+			LawInContext<FunctionCM<Int,TestStructure>>.isWellBehavedWrapper(a.get)(context)
+		}
+	}
+
+	func testFunctionM() {
+		property("FunctionM is a well-behaved Wrapper") <- forAll { (a: FunctionMOf<Int,TestStructure>, context: Int) in
+			LawInContext<FunctionM<Int,TestStructure>>.isWellBehavedWrapper(a.get)(context)
+		}
+	}
+
 	func testFunctionS() {
 		property("FunctionS is a well-behaved Wrapper") <- forAll { (a: FunctionSOf<Int,TestStructure>, context: Int) in
 			LawInContext<FunctionS<Int,TestStructure>>.isWellBehavedWrapper(a.get)(context)
+		}
+	}
+
+	func testFunctionSR() {
+		property("FunctionSR is a well-behaved Wrapper") <- forAll { (a: FunctionSROf<Int,TestSemiring>, context: Int) in
+			LawInContext<FunctionSR<Int,TestSemiring>>.isWellBehavedWrapper(a.get)(context)
 		}
 	}
 
@@ -55,14 +80,25 @@ final class WrapperTests: XCTestCase {
 		}
 	}
 
+	func testTropical() {
+		property("Tropical is a well-behaved Wrapper") <- forAll { (a: TropicalOf<Int>) in
+			Law<Tropical<Int>>.isWellBehavedWrapper(a.get)
+		}
+	}
+
 	static var allTests = [
 		("testAdd",testAdd),
 		("testAnd",testAnd),
 		("testEndofunction",testEndofunction),
+		("testFunctionBS",testFunctionBS),
+		("testFunctionCM",testFunctionCM),
+		("testFunctionM",testFunctionM),
 		("testFunctionS",testFunctionS),
+		("testFunctionSR",testFunctionSR),
 		("testMax",testMax),
 		("testMin",testMin),
 		("testMultiply",testMultiply),
 		("testOr",testOr),
+		("testTropical",testTropical),
 	]
 }

--- a/Tests/AbstractTests/WrapperTests.generated.swift
+++ b/Tests/AbstractTests/WrapperTests.generated.swift
@@ -1,0 +1,68 @@
+// Generated using Sourcery 0.7.2 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import XCTest
+@testable import Abstract
+import SwiftCheck
+
+final class WrapperTests: XCTestCase {
+
+	func testAdd() {
+		property("Add is a well-behaved Wrapper") <- forAll { (a: AddOf<Int>) in
+			Law<Add<Int>>.isWellBehavedWrapper(a.get)
+		}
+	}
+
+	func testAnd() {
+		property("And is a well-behaved Wrapper") <- forAll { (a: And) in
+			Law<And>.isWellBehavedWrapper(a)
+		}
+	}
+
+	func testEndofunction() {
+		property("Endofunction is a well-behaved Wrapper") <- forAll { (a: EndofunctionOf<Int>, context: Int) in
+			LawInContext<Endofunction<Int>>.isWellBehavedWrapper(a.get)(context)
+		}
+	}
+
+	func testFunctionS() {
+		property("FunctionS is a well-behaved Wrapper") <- forAll { (a: FunctionSOf<Int,TestStructure>, context: Int) in
+			LawInContext<FunctionS<Int,TestStructure>>.isWellBehavedWrapper(a.get)(context)
+		}
+	}
+
+	func testMax() {
+		property("Max is a well-behaved Wrapper") <- forAll { (a: MaxOf<Int>) in
+			Law<Max<Int>>.isWellBehavedWrapper(a.get)
+		}
+	}
+
+	func testMin() {
+		property("Min is a well-behaved Wrapper") <- forAll { (a: MinOf<Int>) in
+			Law<Min<Int>>.isWellBehavedWrapper(a.get)
+		}
+	}
+
+	func testMultiply() {
+		property("Multiply is a well-behaved Wrapper") <- forAll { (a: MultiplyOf<Int>) in
+			Law<Multiply<Int>>.isWellBehavedWrapper(a.get)
+		}
+	}
+
+	func testOr() {
+		property("Or is a well-behaved Wrapper") <- forAll { (a: Or) in
+			Law<Or>.isWellBehavedWrapper(a)
+		}
+	}
+
+	static var allTests = [
+		("testAdd",testAdd),
+		("testAnd",testAnd),
+		("testEndofunction",testEndofunction),
+		("testFunctionS",testFunctionS),
+		("testMax",testMax),
+		("testMin",testMin),
+		("testMultiply",testMultiply),
+		("testOr",testOr),
+	]
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -6,11 +6,11 @@ import XCTest
 @testable import AbstractTests
 
 XCTMain([
-	testCase(HomomorphismTests.allTests),
 	testCase(BoundedSemilatticeTests.allTests),
 	testCase(CommutativeMonoidTests.allTests),
+	testCase(HomomorphismTests.allTests),
 	testCase(MonoidTests.allTests),
 	testCase(SemigroupTests.allTests),
 	testCase(SemiringTests.allTests),
-	testCase(WrapperTests.allTests)
+	testCase(WrapperTests.allTests),
 ])

--- a/sourceryTests.sh
+++ b/sourceryTests.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo "Checking for Sourcery..."
+
+if [ -f "Sourcery/sourcery" ]; then
+	echo "Sourcery: Sources/Abstract + Templates/Tests -> Tests/AbstractTests"
+
+	./Sourcery/sourcery --sources Sources/Abstract --templates Templates/Tests --output Tests/AbstractTests
+else
+	echo "Sourcery is not installed, ignoring."
+fi

--- a/sourceryTests.sh
+++ b/sourceryTests.sh
@@ -3,13 +3,23 @@
 echo "Checking for Sourcery..."
 
 if [ -f "Sourcery/sourcery" ]; then
-	echo "Sourcery: Sources/Abstract + Templates/Tests -> Tests/AbstractTests"
+	echo "Generating test files: Sources/Abstract + Templates/Tests -> Tests/AbstractTests"
 
 	./Sourcery/sourcery --sources Sources/Abstract --templates Templates/Tests --output Tests/AbstractTests
 
-	echo "Sourcery: Tests/AbstractTests + Templates/Other/LinuxMain.stencil -> Tests/LinuxMain.swift"
+	echo "Removing first line from generated test files..."
+
+	for filename in Tests/AbstractTests/*.generated.swift; do
+		sed -i '' 1d $filename
+	done
+
+	echo "Generating LinuxMain file: Tests/AbstractTests + Templates/Other/LinuxMain.stencil -> Tests/LinuxMain.swift"
 
 	./Sourcery/sourcery --sources Tests/AbstractTests --templates Templates/Other/LinuxMain.stencil --output Tests/LinuxMain.swift
+
+	echo "Regenerating test files..."
+
+	./Sourcery/sourcery --sources Sources/Abstract --templates Templates/Tests --output Tests/AbstractTests
 
 else
 	echo "Sourcery is not installed, ignoring."

--- a/sourceryTests.sh
+++ b/sourceryTests.sh
@@ -6,6 +6,11 @@ if [ -f "Sourcery/sourcery" ]; then
 	echo "Sourcery: Sources/Abstract + Templates/Tests -> Tests/AbstractTests"
 
 	./Sourcery/sourcery --sources Sources/Abstract --templates Templates/Tests --output Tests/AbstractTests
+
+	echo "Sourcery: Tests/AbstractTests + Templates/Other/LinuxMain.stencil -> Tests/LinuxMain.swift"
+
+	./Sourcery/sourcery --sources Tests/AbstractTests --templates Templates/Other/LinuxMain.stencil --output Tests/LinuxMain.swift
+
 else
 	echo "Sourcery is not installed, ignoring."
 fi


### PR DESCRIPTION
This is a first step, in which I used Sourcery to generate code for tests regarding algebraic structures' laws.

I added the Stencil templates to the git index, but not the Sourcery binary: there's a Xcode build phase that runs Sourcery if present, but it shouldn't be necessary because the generated test files are committed. Also, I'm not sure is a good idea to commit the Sourcery binary: anyway, for the script to work the Sourcery executable (along with its app) must be present in a `Sourcery` folder.

I wasn't able to properly use Sourcery to generate `LinuxMain.swift`: I'm still generating it with a template, but apparently Sourcery ignores the "generated" files in a second pass, so I manually added the references to the `allTests` static variables.

closes #17 