### PR TITLE
Rename `Wrapped` to `WrappedType`

### DIFF
--- a/Sources/Abstract/BoundedSemilattice.swift
+++ b/Sources/Abstract/BoundedSemilattice.swift
@@ -49,7 +49,7 @@ extension Or: BoundedSemilattice {}
 // sourcery: arbitraryFunction
 // sourcery: arbitraryGenericParameterProtocols = "BoundedSemilattice & Equatable"
 public struct FunctionBS<A, M: BoundedSemilattice & Equatable>: Wrapper, BoundedSemilattice, EquatableInContext {
-	public typealias Wrapped = (A) -> M
+	public typealias WrappedType = (A) -> M
 	public typealias Context = A
 
 	public let unwrap: (A) -> M

--- a/Sources/Abstract/CommutativeMonoid.swift
+++ b/Sources/Abstract/CommutativeMonoid.swift
@@ -57,7 +57,7 @@ extension Or: CommutativeMonoid {}
 // sourcery: arbitraryFunction
 // sourcery: arbitraryGenericParameterProtocols = "CommutativeMonoid & Equatable"
 public struct FunctionCM<A, M: CommutativeMonoid & Equatable>: Wrapper, CommutativeMonoid, EquatableInContext {
-	public typealias Wrapped = (A) -> M
+	public typealias WrappedType = (A) -> M
 	public typealias Context = A
 
 	public let unwrap: (A) -> M

--- a/Sources/Abstract/Monoid.swift
+++ b/Sources/Abstract/Monoid.swift
@@ -99,7 +99,7 @@ extension Endofunction: Monoid {
 // sourcery: arbitraryFunction
 // sourcery: arbitraryGenericParameterProtocols = "Monoid & Equatable"
 public struct FunctionM<A, M: Monoid & Equatable>: Wrapper,  Monoid, EquatableInContext {
-	public typealias Wrapped = (A) -> M
+	public typealias WrappedType = (A) -> M
 	public typealias Context = A
 
 	public let unwrap: (A) -> M

--- a/Sources/Abstract/Semigroup.swift
+++ b/Sources/Abstract/Semigroup.swift
@@ -38,7 +38,7 @@ Each type is tested for associativity in `AbstractTests.swift`, and for testing 
 // sourcery: arbitrary
 // sourcery: arbitraryGenericParameterProtocols = "Addable"
 public struct Add<A: Addable>: Wrapper, Semigroup, Equatable {
-	public typealias Wrapped = A
+	public typealias WrappedType = A
 
 	public let unwrap: A
 	
@@ -57,7 +57,7 @@ public struct Add<A: Addable>: Wrapper, Semigroup, Equatable {
 // sourcery: arbitrary
 // sourcery: arbitraryGenericParameterProtocols = "Multipliable"
 public struct Multiply<A: Multipliable>: Wrapper, Semigroup, Equatable {
-	public typealias Wrapped = A
+	public typealias WrappedType = A
 
 	public let unwrap: A
 	
@@ -76,7 +76,7 @@ public struct Multiply<A: Multipliable>: Wrapper, Semigroup, Equatable {
 // sourcery: arbitrary
 // sourcery: arbitraryGenericParameterProtocols = "ComparableToBottom"
 public struct Max<A: ComparableToBottom>: Wrapper, Semigroup, Equatable {
-	public typealias Wrapped = A
+	public typealias WrappedType = A
 
 	public let unwrap: A
 	
@@ -95,7 +95,7 @@ public struct Max<A: ComparableToBottom>: Wrapper, Semigroup, Equatable {
 // sourcery: arbitrary
 // sourcery: arbitraryGenericParameterProtocols = "ComparableToTop"
 public struct Min<A: ComparableToTop>: Wrapper, Semigroup, Equatable {
-	public typealias Wrapped = A
+	public typealias WrappedType = A
 
 	public let unwrap: A
 	
@@ -112,7 +112,7 @@ public struct Min<A: ComparableToTop>: Wrapper, Semigroup, Equatable {
 
 // sourcery: arbitrary
 public struct And: Wrapper, Semigroup, Equatable, ExpressibleByBooleanLiteral {
-	public typealias Wrapped = Bool
+	public typealias WrappedType = Bool
 	public typealias BooleanLiteralType = Bool
 
 	public let unwrap: Bool
@@ -134,7 +134,7 @@ public struct And: Wrapper, Semigroup, Equatable, ExpressibleByBooleanLiteral {
 
 // sourcery: arbitrary
 public struct Or: Wrapper, Semigroup, Equatable, ExpressibleByBooleanLiteral {
-	public typealias Wrapped = Bool
+	public typealias WrappedType = Bool
 	public typealias BooleanLiteralType = Bool
 
 	public let unwrap: Bool
@@ -158,7 +158,7 @@ public struct Or: Wrapper, Semigroup, Equatable, ExpressibleByBooleanLiteral {
 // sourcery: arbitrary
 // sourcery: arbitraryGenericParameterProtocols = "Equatable"
 public struct First<A: Equatable>: Wrapper, Semigroup, Equatable {
-    public typealias Wrapped = A
+    public typealias WrappedType = A
     
     public let unwrap: A
     
@@ -177,7 +177,7 @@ public struct First<A: Equatable>: Wrapper, Semigroup, Equatable {
 // sourcery: arbitrary
 // sourcery: arbitraryGenericParameterProtocols = "Equatable"
 public struct Last<A: Equatable>: Wrapper, Semigroup, Equatable {
-    public typealias Wrapped = A
+    public typealias WrappedType = A
     
     public let unwrap: A
     
@@ -190,10 +190,12 @@ public struct Last<A: Equatable>: Wrapper, Semigroup, Equatable {
     }
 }
 
+//: ------
+
 // sourcery: fixedTypesForPropertyBasedTests = "Int"
 // sourcery: requiredContextForPropertyBasedTests = "Int"
 public struct Endofunction<A: Equatable>: Wrapper, Semigroup, EquatableInContext {
-	public typealias Wrapped = (A) -> A
+	public typealias WrappedType = (A) -> A
 	public typealias Context = A
 
 	public let unwrap: (A) -> A
@@ -222,7 +224,7 @@ public struct Endofunction<A: Equatable>: Wrapper, Semigroup, EquatableInContext
 // sourcery: arbitraryFunction
 // sourcery: arbitraryGenericParameterProtocols = "Semigroup & Equatable"
 public struct FunctionS<A, S: Semigroup & Equatable>: Wrapper, Semigroup, EquatableInContext {
-	public typealias Wrapped = (A) -> S
+	public typealias WrappedType = (A) -> S
 	public typealias Context = A
 
 	public let unwrap: (A) -> S

--- a/Sources/Abstract/Semiring.swift
+++ b/Sources/Abstract/Semiring.swift
@@ -56,10 +56,10 @@ extension LawInContext where Element: Semiring {
 }
 
 /*:
-Interestingly, if for type `A` both `Additive` and `Multiplicative` are `Wrapper` and the `Wrapped` type is `A` itself, we can derive the implementation of all the functions:
+Interestingly, if for type `A` both `Additive` and `Multiplicative` are `Wrapper` and the `WrappedType` type is `A` itself, we can derive the implementation of all the functions:
 */
 
-extension Semiring where Additive: Wrapper, Additive.Wrapped == Self {
+extension Semiring where Additive: Wrapper, Additive.WrappedType == Self {
 	public static func <>+(left: Self, right: Self) -> Self {
 		return (Additive.init(left) <> Additive.init(right)).unwrap
 	}
@@ -69,7 +69,7 @@ extension Semiring where Additive: Wrapper, Additive.Wrapped == Self {
 	}
 }
 
-extension Semiring where Multiplicative: Wrapper, Multiplicative.Wrapped == Self {
+extension Semiring where Multiplicative: Wrapper, Multiplicative.WrappedType == Self {
 	public static func <>*(left: Self, right: Self) -> Self {
 		return (Multiplicative.init(left) <> Multiplicative.init(right)).unwrap
 	}
@@ -83,7 +83,7 @@ extension Semiring where Multiplicative: Wrapper, Multiplicative.Wrapped == Self
 If instead the semiring is a wrapper of `A`, and both its additive and multiplicative are wrappers of `A`, we can still derive an abstract implementation for the functions:
 */
 
-extension Semiring where Self: Wrapper, Additive: Wrapper, Self.Wrapped == Additive.Wrapped {
+extension Semiring where Self: Wrapper, Additive: Wrapper, Self.WrappedType == Additive.WrappedType {
 	public static func <>+(left: Self, right: Self) -> Self {
 		return Self.init((Additive.init(left.unwrap) <> Additive.init(right.unwrap)).unwrap)
 	}
@@ -93,7 +93,7 @@ extension Semiring where Self: Wrapper, Additive: Wrapper, Self.Wrapped == Addit
 	}
 }
 
-extension Semiring where Self: Wrapper, Multiplicative: Wrapper, Self.Wrapped == Multiplicative.Wrapped {
+extension Semiring where Self: Wrapper, Multiplicative: Wrapper, Self.WrappedType == Multiplicative.WrappedType {
 	public static func <>*(left: Self, right: Self) -> Self {
 		return Self.init((Multiplicative.init(left.unwrap) <> Multiplicative.init(right.unwrap)).unwrap)
 	}
@@ -123,7 +123,7 @@ extension Bool: Semiring {
 // sourcery: additionalGenericParameterSubtypeRequirements = "Additive: Equatable"
 // sourcery: additionalGenericParameterSubtypeRequirements = "Multiplicative: Equatable"
 public struct FunctionSR<A,SR: Semiring & Equatable>: Wrapper, Semiring, EquatableInContext where SR.Additive: Equatable, SR.Multiplicative: Equatable {
-	public typealias Wrapped = (A) -> SR
+	public typealias WrappedType = (A) -> SR
 	public typealias Additive = FunctionCM<A,SR.Additive>
 	public typealias Multiplicative = FunctionM<A,SR.Multiplicative>
 	public typealias Context = A
@@ -169,7 +169,7 @@ A Tropical semiring is just a fancy name for a (min, +)-semiring. This semiring 
 // sourcery: arbitrary
 // sourcery: arbitraryGenericParameterProtocols = "ComparableToTop & Addable"
 public struct Tropical<A: ComparableToTop & Addable & Equatable>: Wrapper, Semiring, Equatable {
-    public typealias Wrapped = A
+    public typealias WrappedType = A
     public typealias Additive = Min<A>
     public typealias Multiplicative = Add<A>
     

--- a/Sources/Abstract/Wrapper.swift
+++ b/Sources/Abstract/Wrapper.swift
@@ -3,7 +3,7 @@
 
 And abstract definition for a type that wraps another, and guarantees both initialization with and access to the wrapped value.
 
-For a wrapper to be *well-behaved* the requirement is that, by retrieving the `Wrapped` from a `Wrapper`, then constructing the `Wrapper` again with the retrieved value, we end up building the same `Wrapper` as before:
+For a wrapper to be *well-behaved* the requirement is that, by retrieving the `WrappedType` from a `Wrapper`, then constructing the `Wrapper` again with the retrieved value, we end up building the same `Wrapper` as before:
 
 A.init(a.unwrap) == a
 
@@ -11,15 +11,15 @@ This means that `Wrapper.init` and `Wrapper.unwrap` must be inverse to each othe
 */
 
 public protocol Wrapper {
-	associatedtype Wrapped
+	associatedtype WrappedType
 
-	init(_ value: Wrapped)
+	init(_ value: WrappedType)
 
-	var unwrap: Wrapped { get }
+	var unwrap: WrappedType { get }
 }
 
 extension Wrapper {
-	public init(unwrap: Wrapped) {
+	public init(unwrap: WrappedType) {
 		self.init(unwrap)
 	}
 }
@@ -37,10 +37,10 @@ extension LawInContext where Element: Wrapper {
 }
 
 /*:
-If the `Wrapped` element is `Equatable`, we can define the static `==` function for a `Wrapper` (unfortunately, the `Equatable` conformance must be declared explicitly for every wrapper).
+If the `WrappedType` element is `Equatable`, we can define the static `==` function for a `Wrapper` (unfortunately, the `Equatable` conformance must be declared explicitly for every wrapper).
 */
 
-extension Wrapper where Wrapped: Equatable {
+extension Wrapper where WrappedType: Equatable {
 	public static func == (left: Self, right: Self) -> Bool {
 		return left.unwrap == right.unwrap
 	}

--- a/Tests/Utility/CustomArbitraryTypes.swift
+++ b/Tests/Utility/CustomArbitraryTypes.swift
@@ -65,7 +65,7 @@ struct TestSemiring: Arbitrary, Semiring, Equatable {
 }
 
 struct TestProduct: CoArbitrary, Hashable, Arbitrary, Wrapper {
-	typealias Wrapped = (Int,Int)
+	typealias WrappedType = (Int,Int)
 
 	let unwrap: (Int,Int)
 	


### PR DESCRIPTION
Just a quick renaming to avoid conflating with the `Wrapped` generic parameter of `Optional`.