### PR TITLE
Added FirstM and LastM monoids

### DIFF
--- a/Sources/Abstract/Monoid.swift
+++ b/Sources/Abstract/Monoid.swift
@@ -86,6 +86,62 @@ extension Or: Monoid {
 
 //: ------
 
+/*:
+`FirstM` and `LastM` work like the pretty self-explanatory `First` and `Last` except that the `.empty` value is always discarded: `FirstM.empty <> _` will return the second value, and `_ <> LastM.empty` will return the first value.
+*/
+
+// sourcery: fixedTypesForPropertyBasedTests = "TestStructure"
+// sourcery: arbitrary
+// sourcery: arbitraryGenericParameterProtocols = "Monoid & Equatable"
+public struct FirstM<A: Monoid & Equatable>: Wrapper, Monoid, Equatable {
+	public typealias WrappedType = A
+
+	public let unwrap: A
+
+	public init(_ value: A) {
+		self.unwrap = value
+	}
+
+	public static func <> (left: FirstM, right: FirstM) -> FirstM {
+		switch (left,right) {
+		case (FirstM.empty,FirstM.empty):
+			return left
+		case (FirstM.empty,_):
+			return right
+		default:
+			return left
+		}
+	}
+}
+
+//: ------
+
+// sourcery: fixedTypesForPropertyBasedTests = "TestStructure"
+// sourcery: arbitrary
+// sourcery: arbitraryGenericParameterProtocols = "Monoid & Equatable"
+public struct LastM<A: Monoid & Equatable>: Wrapper, Monoid, Equatable {
+	public typealias WrappedType = A
+
+	public let unwrap: A
+
+	public init(_ value: A) {
+		self.unwrap = value
+	}
+
+	public static func <> (left: LastM, right: LastM) -> LastM {
+		switch (left,right) {
+		case (LastM.empty,LastM.empty):
+			return right
+		case (_,LastM.empty):
+			return left
+		default:
+			return right
+		}
+	}
+}
+
+//: ------
+
 extension Endofunction: Monoid {
 	public static var empty: Endofunction<A> {
 		return Endofunction<A> { $0 }

--- a/Sources/Abstract/Wrapper.swift
+++ b/Sources/Abstract/Wrapper.swift
@@ -45,3 +45,13 @@ extension Wrapper where WrappedType: Equatable {
 		return left.unwrap == right.unwrap
 	}
 }
+
+/*:
+If the `WrappedType` element is `Monoid`, we can define the static `empty` function for a `Wrapper` (unfortunately, the `Monoid` conformance must be declared explicitly for every wrapper).
+*/
+
+extension Wrapper where WrappedType: Monoid {
+	public static var empty: Self {
+		return Self.init(WrappedType.empty)
+	}
+}

--- a/Tests/AbstractTests/MonoidTests.generated.swift
+++ b/Tests/AbstractTests/MonoidTests.generated.swift
@@ -26,6 +26,12 @@ final class MonoidTests: XCTestCase {
 		}
 	}
 
+	func testFirstM() {
+	property("FirstM is a Monoid") <- forAll { (a: FirstMOf<TestStructure>) in
+			Law<FirstM<TestStructure>>.isNeutralToEmpty(a.get)
+		}
+	}
+
 	func testFunctionBS() {
 	property("FunctionBS is a Monoid") <- forAll { (a: FunctionBSOf<Int,TestStructure>, context: Int) in
 			LawInContext<FunctionBS<Int,TestStructure>>.isNeutralToEmpty(a.get)(context)
@@ -41,6 +47,12 @@ final class MonoidTests: XCTestCase {
 	func testFunctionM() {
 	property("FunctionM is a Monoid") <- forAll { (a: FunctionMOf<Int,TestStructure>, context: Int) in
 			LawInContext<FunctionM<Int,TestStructure>>.isNeutralToEmpty(a.get)(context)
+		}
+	}
+
+	func testLastM() {
+	property("LastM is a Monoid") <- forAll { (a: LastMOf<TestStructure>) in
+			Law<LastM<TestStructure>>.isNeutralToEmpty(a.get)
 		}
 	}
 
@@ -78,9 +90,11 @@ final class MonoidTests: XCTestCase {
 		("testAdd",testAdd),
 		("testAnd",testAnd),
 		("testEndofunction",testEndofunction),
+		("testFirstM",testFirstM),
 		("testFunctionBS",testFunctionBS),
 		("testFunctionCM",testFunctionCM),
 		("testFunctionM",testFunctionM),
+		("testLastM",testLastM),
 		("testMax",testMax),
 		("testMin",testMin),
 		("testMultiply",testMultiply),

--- a/Tests/AbstractTests/SemigroupTests.generated.swift
+++ b/Tests/AbstractTests/SemigroupTests.generated.swift
@@ -32,6 +32,12 @@ final class SemigroupTests: XCTestCase {
 		}
 	}
 
+	func testFirstM() {
+		property("FirstM is a Semigroup") <- forAll { (a: FirstMOf<TestStructure>, b: FirstMOf<TestStructure>, c: FirstMOf<TestStructure>) in
+			Law<FirstM<TestStructure>>.isAssociative(a.get,b.get,c.get)
+		}
+	}
+
 	func testFunctionBS() {
 		property("FunctionBS is a Semigroup") <- forAll { (a: FunctionBSOf<Int,TestStructure>, b: FunctionBSOf<Int,TestStructure>, c: FunctionBSOf<Int,TestStructure>, context: Int) in
 			LawInContext<FunctionBS<Int,TestStructure>>.isAssociative(a.get,b.get,c.get)(context)
@@ -59,6 +65,12 @@ final class SemigroupTests: XCTestCase {
 	func testLast() {
 		property("Last is a Semigroup") <- forAll { (a: LastOf<Int>, b: LastOf<Int>, c: LastOf<Int>) in
 			Law<Last<Int>>.isAssociative(a.get,b.get,c.get)
+		}
+	}
+
+	func testLastM() {
+		property("LastM is a Semigroup") <- forAll { (a: LastMOf<TestStructure>, b: LastMOf<TestStructure>, c: LastMOf<TestStructure>) in
+			Law<LastM<TestStructure>>.isAssociative(a.get,b.get,c.get)
 		}
 	}
 
@@ -97,11 +109,13 @@ final class SemigroupTests: XCTestCase {
 		("testAnd",testAnd),
 		("testEndofunction",testEndofunction),
 		("testFirst",testFirst),
+		("testFirstM",testFirstM),
 		("testFunctionBS",testFunctionBS),
 		("testFunctionCM",testFunctionCM),
 		("testFunctionM",testFunctionM),
 		("testFunctionS",testFunctionS),
 		("testLast",testLast),
+		("testLastM",testLastM),
 		("testMax",testMax),
 		("testMin",testMin),
 		("testMultiply",testMultiply),

--- a/Tests/AbstractTests/WrapperTests.generated.swift
+++ b/Tests/AbstractTests/WrapperTests.generated.swift
@@ -32,6 +32,12 @@ final class WrapperTests: XCTestCase {
 		}
 	}
 
+	func testFirstM() {
+		property("FirstM is a well-behaved Wrapper") <- forAll { (a: FirstMOf<TestStructure>) in
+			Law<FirstM<TestStructure>>.isWellBehavedWrapper(a.get)
+		}
+	}
+
 	func testFunctionBS() {
 		property("FunctionBS is a well-behaved Wrapper") <- forAll { (a: FunctionBSOf<Int,TestStructure>, context: Int) in
 			LawInContext<FunctionBS<Int,TestStructure>>.isWellBehavedWrapper(a.get)(context)
@@ -65,6 +71,12 @@ final class WrapperTests: XCTestCase {
 	func testLast() {
 		property("Last is a well-behaved Wrapper") <- forAll { (a: LastOf<Int>) in
 			Law<Last<Int>>.isWellBehavedWrapper(a.get)
+		}
+	}
+
+	func testLastM() {
+		property("LastM is a well-behaved Wrapper") <- forAll { (a: LastMOf<TestStructure>) in
+			Law<LastM<TestStructure>>.isWellBehavedWrapper(a.get)
 		}
 	}
 
@@ -103,12 +115,14 @@ final class WrapperTests: XCTestCase {
 		("testAnd",testAnd),
 		("testEndofunction",testEndofunction),
 		("testFirst",testFirst),
+		("testFirstM",testFirstM),
 		("testFunctionBS",testFunctionBS),
 		("testFunctionCM",testFunctionCM),
 		("testFunctionM",testFunctionM),
 		("testFunctionS",testFunctionS),
 		("testFunctionSR",testFunctionSR),
 		("testLast",testLast),
+		("testLastM",testLastM),
 		("testMax",testMax),
 		("testMin",testMin),
 		("testMultiply",testMultiply),

--- a/Tests/Utility/Arbitrary.generated.swift
+++ b/Tests/Utility/Arbitrary.generated.swift
@@ -52,6 +52,23 @@ struct FirstOf<T>: Arbitrary where T: Arbitrary & Equatable {
     }
 }
 
+struct FirstMOf<T>: Arbitrary where T: Arbitrary & Monoid & Equatable {
+    let get: FirstM<T>
+    init(_ get: FirstM<T>) {
+        self.get = get
+    }
+
+    public static var arbitrary: Gen<FirstMOf<T>> {
+        return Gen<FirstM<T>>
+            .compose {
+                FirstM<T>.init(
+                    unwrap: $0.generate()
+                )
+            }
+            .map(FirstMOf<T>.init)
+    }
+}
+
 struct LastOf<T>: Arbitrary where T: Arbitrary & Equatable {
     let get: Last<T>
     init(_ get: Last<T>) {
@@ -66,6 +83,23 @@ struct LastOf<T>: Arbitrary where T: Arbitrary & Equatable {
                 )
             }
             .map(LastOf<T>.init)
+    }
+}
+
+struct LastMOf<T>: Arbitrary where T: Arbitrary & Monoid & Equatable {
+    let get: LastM<T>
+    init(_ get: LastM<T>) {
+        self.get = get
+    }
+
+    public static var arbitrary: Gen<LastMOf<T>> {
+        return Gen<LastM<T>>
+            .compose {
+                LastM<T>.init(
+                    unwrap: $0.generate()
+                )
+            }
+            .map(LastMOf<T>.init)
     }
 }
 


### PR DESCRIPTION
I defined `FirstM<A: Monoid>: Monoid` and `LastM<A: Monoid>: Monoid` types. Not sure about other use cases, but I found something like `LastM` useful when working with the `Writer` monad: its `log` type has to be a monoid, and by using `LastM` I can always take the last value for it except when it's `.empty`.

Seems useful? Makes sense?