### PR TITLE
A bunch of additions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ Abstract.xcodeproj/project.xcworkspace/xcuserdata
 Abstract.xcodeproj/xcuserdata
 Carthage/
 Sourcery/
+Play.playground
+Play.xcworkspace

--- a/Abstract.xcodeproj/project.pbxproj
+++ b/Abstract.xcodeproj/project.pbxproj
@@ -171,24 +171,17 @@
 		0951F2431F09690200EA362C /* SwiftCheck.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftCheck.framework; path = Carthage/Build/Mac/SwiftCheck.framework; sourceTree = "<group>"; };
 		0951F2441F09690200EA362C /* SwiftCheck.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftCheck.framework; path = Carthage/Build/tvOS/SwiftCheck.framework; sourceTree = "<group>"; };
 		09F9FD0E1EEE5CE8002342E5 /* Homomorphism.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Homomorphism.swift; sourceTree = "<group>"; };
-		380A4B0D1F1B71AA002D70E0 /* SemigroupTests.stencil */ = {isa = PBXFileReference; lastKnownFileType = text; path = SemigroupTests.stencil; sourceTree = "<group>"; };
 		380A4B141F1B7336002D70E0 /* SemigroupTests.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SemigroupTests.generated.swift; sourceTree = "<group>"; };
-		380A4B181F1B7624002D70E0 /* WrapperTests.stencil */ = {isa = PBXFileReference; lastKnownFileType = text; path = WrapperTests.stencil; sourceTree = "<group>"; };
 		380A4B191F1B775F002D70E0 /* WrapperTests.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrapperTests.generated.swift; sourceTree = "<group>"; };
-		380A4B1E1F1BD550002D70E0 /* MonoidTests.stencil */ = {isa = PBXFileReference; lastKnownFileType = text; path = MonoidTests.stencil; sourceTree = "<group>"; };
 		380A4B1F1F1BE383002D70E0 /* MonoidTests.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MonoidTests.generated.swift; sourceTree = "<group>"; };
-		380A4B231F1BE3F9002D70E0 /* CommutativeMonoidTests.stencil */ = {isa = PBXFileReference; lastKnownFileType = text; path = CommutativeMonoidTests.stencil; sourceTree = "<group>"; };
 		380A4B241F1BF5AC002D70E0 /* CommutativeMonoidTests.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommutativeMonoidTests.generated.swift; sourceTree = "<group>"; };
-		380A4B281F1BF605002D70E0 /* BoundedSemilatticeTests.stencil */ = {isa = PBXFileReference; lastKnownFileType = text; path = BoundedSemilatticeTests.stencil; sourceTree = "<group>"; };
 		380A4B291F1BF66B002D70E0 /* BoundedSemilatticeTests.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BoundedSemilatticeTests.generated.swift; sourceTree = "<group>"; };
-		380A4B2D1F1BF743002D70E0 /* SemiringTests.stencil */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = SemiringTests.stencil; sourceTree = "<group>"; };
 		380A4B301F1BF83B002D70E0 /* SemiringTests.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SemiringTests.generated.swift; sourceTree = "<group>"; };
-		380A4B351F1BFA9F002D70E0 /* LinuxMain.stencil */ = {isa = PBXFileReference; lastKnownFileType = text; path = LinuxMain.stencil; sourceTree = "<group>"; };
-		38273AD21F2484DD000AB0C8 /* Arbitrary.stencil */ = {isa = PBXFileReference; lastKnownFileType = text; path = Arbitrary.stencil; sourceTree = "<group>"; };
 		38273AD41F248569000AB0C8 /* CustomArbitraryTypes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomArbitraryTypes.swift; sourceTree = "<group>"; };
 		38273AD81F2485FB000AB0C8 /* Arbitrary.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Arbitrary.generated.swift; sourceTree = "<group>"; };
 		3853BF9D1EF11D7400791099 /* Wrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Wrapper.swift; sourceTree = "<group>"; };
 		3853BF9F1EF1294400791099 /* Semiring.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Semiring.swift; sourceTree = "<group>"; };
+		38757E101F4D85AB0059AD71 /* Templates */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Templates; sourceTree = "<group>"; };
 		38943A681EEC25AE00F587AD /* HomomorphismTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomomorphismTests.swift; sourceTree = "<group>"; };
 		38943A761EEC31DA00F587AD /* Adapters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Adapters.swift; sourceTree = "<group>"; };
 		38943A781EEC4EFF00F587AD /* Monoid.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Monoid.swift; sourceTree = "<group>"; };
@@ -287,45 +280,6 @@
 			path = Abstract;
 			sourceTree = "<group>";
 		};
-		380A4B0B1F1B71AA002D70E0 /* Templates */ = {
-			isa = PBXGroup;
-			children = (
-				380A4B341F1BFA9F002D70E0 /* LinuxMain */,
-				38273AD11F2484DD000AB0C8 /* Other */,
-				380A4B0C1F1B71AA002D70E0 /* Tests */,
-			);
-			path = Templates;
-			sourceTree = "<group>";
-		};
-		380A4B0C1F1B71AA002D70E0 /* Tests */ = {
-			isa = PBXGroup;
-			children = (
-				380A4B281F1BF605002D70E0 /* BoundedSemilatticeTests.stencil */,
-				380A4B231F1BE3F9002D70E0 /* CommutativeMonoidTests.stencil */,
-				380A4B1E1F1BD550002D70E0 /* MonoidTests.stencil */,
-				380A4B0D1F1B71AA002D70E0 /* SemigroupTests.stencil */,
-				380A4B2D1F1BF743002D70E0 /* SemiringTests.stencil */,
-				380A4B181F1B7624002D70E0 /* WrapperTests.stencil */,
-			);
-			path = Tests;
-			sourceTree = "<group>";
-		};
-		380A4B341F1BFA9F002D70E0 /* LinuxMain */ = {
-			isa = PBXGroup;
-			children = (
-				380A4B351F1BFA9F002D70E0 /* LinuxMain.stencil */,
-			);
-			path = LinuxMain;
-			sourceTree = "<group>";
-		};
-		38273AD11F2484DD000AB0C8 /* Other */ = {
-			isa = PBXGroup;
-			children = (
-				38273AD21F2484DD000AB0C8 /* Arbitrary.stencil */,
-			);
-			path = Other;
-			sourceTree = "<group>";
-		};
 		38273AD31F248569000AB0C8 /* Utility */ = {
 			isa = PBXGroup;
 			children = (
@@ -358,6 +312,7 @@
 		38D737B41EE9A6BA000BAF0C = {
 			isa = PBXGroup;
 			children = (
+				38757E101F4D85AB0059AD71 /* Templates */,
 				38D737DF1EE9A745000BAF0C /* Abstract.h */,
 				38B83C9D1EED8D11007AB12A /* README.md */,
 				38D737E01EE9A745000BAF0C /* Info.plist */,
@@ -366,7 +321,6 @@
 				38943A6A1EEC287000F587AD /* Frameworks */,
 				38D737C81EE9A729000BAF0C /* Products */,
 				38D737BC1EE9A711000BAF0C /* Sources */,
-				380A4B0B1F1B71AA002D70E0 /* Templates */,
 				38D737BE1EE9A711000BAF0C /* Tests */,
 			);
 			sourceTree = "<group>";

--- a/Abstract.xcodeproj/xcshareddata/xcschemes/Abstract-tvOS.xcscheme
+++ b/Abstract.xcodeproj/xcshareddata/xcschemes/Abstract-tvOS.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "0950FF191F09480A00513DF7"
-               BuildableName = "Abstract_tvOS.framework"
+               BuildableName = "Abstract.framework"
                BlueprintName = "Abstract-tvOS"
                ReferencedContainer = "container:Abstract.xcodeproj">
             </BuildableReference>
@@ -44,7 +44,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "0950FF191F09480A00513DF7"
-            BuildableName = "Abstract_tvOS.framework"
+            BuildableName = "Abstract.framework"
             BlueprintName = "Abstract-tvOS"
             ReferencedContainer = "container:Abstract.xcodeproj">
          </BuildableReference>
@@ -66,7 +66,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "0950FF191F09480A00513DF7"
-            BuildableName = "Abstract_tvOS.framework"
+            BuildableName = "Abstract.framework"
             BlueprintName = "Abstract-tvOS"
             ReferencedContainer = "container:Abstract.xcodeproj">
          </BuildableReference>
@@ -84,7 +84,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "0950FF191F09480A00513DF7"
-            BuildableName = "Abstract_tvOS.framework"
+            BuildableName = "Abstract.framework"
             BlueprintName = "Abstract-tvOS"
             ReferencedContainer = "container:Abstract.xcodeproj">
          </BuildableReference>

--- a/Abstract.xcodeproj/xcshareddata/xcschemes/Abstract-watchOS.xcscheme
+++ b/Abstract.xcodeproj/xcshareddata/xcschemes/Abstract-watchOS.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "0950FF451F094A0100513DF7"
-               BuildableName = "Abstract_watchOS.framework"
+               BuildableName = "Abstract.framework"
                BlueprintName = "Abstract-watchOS"
                ReferencedContainer = "container:Abstract.xcodeproj">
             </BuildableReference>
@@ -47,7 +47,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "0950FF451F094A0100513DF7"
-            BuildableName = "Abstract_watchOS.framework"
+            BuildableName = "Abstract.framework"
             BlueprintName = "Abstract-watchOS"
             ReferencedContainer = "container:Abstract.xcodeproj">
          </BuildableReference>
@@ -65,7 +65,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "0950FF451F094A0100513DF7"
-            BuildableName = "Abstract_watchOS.framework"
+            BuildableName = "Abstract.framework"
             BlueprintName = "Abstract-watchOS"
             ReferencedContainer = "container:Abstract.xcodeproj">
          </BuildableReference>

--- a/Sources/Abstract/BoundedSemilattice.swift
+++ b/Sources/Abstract/BoundedSemilattice.swift
@@ -28,6 +28,41 @@ extension LawInContext where Element: BoundedSemilattice {
 ## Types
 */
 
+// sourcery: fixedTypesForPropertyBasedTests = "TestStructure"
+// sourcery: arbitrary
+// sourcery: arbitraryGenericParameterProtocols = "BoundedSemilattice & Equatable"
+public struct OptionalBS<T>: BoundedSemilattice, Wrapper, Equatable where T: BoundedSemilattice & Equatable {
+	public typealias WrappedType = T?
+
+	public let unwrap: T?
+	public init(_ value: T?) {
+		self.unwrap = value
+	}
+
+	public static var empty: OptionalBS<T> {
+		return .init(nil)
+	}
+
+	public static func <> (_ left: OptionalBS, _ right: OptionalBS) -> OptionalBS {
+		switch (left.unwrap,right.unwrap) {
+		case (.some(let leftValue),.some(let rightValue)):
+			return .init(leftValue <> rightValue)
+		case (.some,_):
+			return left
+		case (_,.some):
+			return right
+		default:
+			return .init(nil)
+		}
+	}
+
+	public static func == (_ left: OptionalBS, _ right: OptionalBS) -> Bool {
+		return left.unwrap == right.unwrap
+	}
+}
+
+//: ------
+
 extension Max: BoundedSemilattice {}
 
 //: ------

--- a/Sources/Abstract/CommutativeMonoid.swift
+++ b/Sources/Abstract/CommutativeMonoid.swift
@@ -28,6 +28,41 @@ extension LawInContext where Element: CommutativeMonoid {
 ## Types
 */
 
+// sourcery: fixedTypesForPropertyBasedTests = "TestStructure"
+// sourcery: arbitrary
+// sourcery: arbitraryGenericParameterProtocols = "CommutativeMonoid & Equatable"
+public struct OptionalCM<T>: CommutativeMonoid, Wrapper, Equatable where T: CommutativeMonoid & Equatable {
+	public typealias WrappedType = T?
+
+	public let unwrap: T?
+	public init(_ value: T?) {
+		self.unwrap = value
+	}
+
+	public static var empty: OptionalCM<T> {
+		return .init(nil)
+	}
+
+	public static func <> (_ left: OptionalCM, _ right: OptionalCM) -> OptionalCM {
+		switch (left.unwrap,right.unwrap) {
+		case (.some(let leftValue),.some(let rightValue)):
+			return .init(leftValue <> rightValue)
+		case (.some,_):
+			return left
+		case (_,.some):
+			return right
+		default:
+			return .init(nil)
+		}
+	}
+
+	public static func == (_ left: OptionalCM, _ right: OptionalCM) -> Bool {
+		return left.unwrap == right.unwrap
+	}
+}
+
+//: ------
+
 extension Add: CommutativeMonoid {}
 
 //: ------

--- a/Sources/Abstract/Monoid.swift
+++ b/Sources/Abstract/Monoid.swift
@@ -38,6 +38,16 @@ Each type again is tested for the new laws in `AbstractTests.swift`.
 
 //: ------
 
+extension String: Monoid {
+	public static let empty: String = ""
+
+	public static func <> (left: String, right: String) -> String {
+		return left + right
+	}
+}
+
+//: ------
+
 // sourcery: fixedTypesForPropertyBasedTests = "TestStructure"
 // sourcery: arbitrary
 // sourcery: arbitraryGenericParameterProtocols = "Monoid & Equatable"

--- a/Sources/Abstract/Monoid.swift
+++ b/Sources/Abstract/Monoid.swift
@@ -50,6 +50,32 @@ extension String: Monoid {
 
 // sourcery: fixedTypesForPropertyBasedTests = "TestStructure"
 // sourcery: arbitrary
+// sourcery: arbitraryGenericParameterProtocols = "Equatable"
+public struct ArrayEq<T>: Wrapper, Monoid, Equatable where T: Equatable {
+	public typealias WrappedType = [T]
+
+	public let unwrap: [T]
+	public init(_ value: [T]) {
+		self.unwrap = value
+	}
+
+	public static func == (left: ArrayEq, right: ArrayEq) -> Bool {
+		return left.unwrap == right.unwrap
+	}
+
+	public static var empty: ArrayEq<T> {
+		return .init([])
+	}
+
+	public static func <> (left: ArrayEq, right: ArrayEq) -> ArrayEq {
+		return ArrayEq.init(left.unwrap + right.unwrap)
+	}
+}
+
+//: ------
+
+// sourcery: fixedTypesForPropertyBasedTests = "TestStructure"
+// sourcery: arbitrary
 // sourcery: arbitraryGenericParameterProtocols = "Monoid & Equatable"
 public struct OptionalM<T>: Monoid, Wrapper, Equatable where T: Monoid & Equatable {
 	public typealias WrappedType = T?

--- a/Sources/Abstract/Monoid.swift
+++ b/Sources/Abstract/Monoid.swift
@@ -38,6 +38,41 @@ Each type again is tested for the new laws in `AbstractTests.swift`.
 
 //: ------
 
+// sourcery: fixedTypesForPropertyBasedTests = "TestStructure"
+// sourcery: arbitrary
+// sourcery: arbitraryGenericParameterProtocols = "Monoid & Equatable"
+public struct OptionalM<T>: Monoid, Wrapper, Equatable where T: Monoid & Equatable {
+	public typealias WrappedType = T?
+
+	public let unwrap: T?
+	public init(_ value: T?) {
+		self.unwrap = value
+	}
+
+	public static var empty: OptionalM<T> {
+		return .init(nil)
+	}
+
+	public static func <> (_ left: OptionalM, _ right: OptionalM) -> OptionalM {
+		switch (left.unwrap,right.unwrap) {
+		case (.some(let leftValue),.some(let rightValue)):
+			return .init(leftValue <> rightValue)
+		case (.some,_):
+			return left
+		case (_,.some):
+			return right
+		default:
+			return .init(nil)
+		}
+	}
+
+	public static func == (_ left: OptionalM, _ right: OptionalM) -> Bool {
+		return left.unwrap == right.unwrap
+	}
+}
+
+//: ------
+
 extension Add: Monoid {
 	public static var empty: Add<A> {
 		return Add.init(A.zero)

--- a/Sources/Abstract/Semigroup.swift
+++ b/Sources/Abstract/Semigroup.swift
@@ -34,6 +34,39 @@ Each type is tested for associativity in `AbstractTests.swift`, and for testing 
 
 //: ------
 
+// sourcery: fixedTypesForPropertyBasedTests = "TestStructure"
+// sourcery: arbitrary
+// sourcery: arbitraryGenericParameterProtocols = "Semigroup & Equatable"
+public struct OptionalS<T>: Semigroup, Wrapper, Equatable where T: Semigroup & Equatable {
+	public typealias WrappedType = T?
+
+	public let unwrap: T?
+
+	public init(_ value: T?) {
+		self.unwrap = value
+	}
+
+	public static func <> (_ left: OptionalS, _ right: OptionalS) -> OptionalS {
+		switch (left.unwrap,right.unwrap) {
+		case (.some(let leftValue),.some(let rightValue)):
+			return .init(leftValue <> rightValue)
+		case (.some,_):
+			return left
+		case (_,.some):
+			return right
+		default:
+			return .init(nil)
+		}
+	}
+
+	public static func == (_ left: OptionalS, _ right: OptionalS) -> Bool {
+		return left.unwrap == right.unwrap
+	}
+}
+
+
+//: ------
+
 // sourcery: fixedTypesForPropertyBasedTests = "Int"
 // sourcery: arbitrary
 // sourcery: arbitraryGenericParameterProtocols = "Addable"

--- a/Templates/Tests/MonoidTests.stencil
+++ b/Templates/Tests/MonoidTests.stencil
@@ -9,7 +9,7 @@ final class {{ protocolName }}Tests: XCTestCase {
 
 	func test{{ type.name }}() {
 {% if type.isGeneric %}
-	property("{{ type.name }} is a {{ protocolName }}") <- forAll { (a: {{ type.name }}Of<{{ type.annotations.fixedTypesForPropertyBasedTests }}>{% if type.annotations.requiredContextForPropertyBasedTests %}, context: {{ type.annotations.requiredContextForPropertyBasedTests }}{% else %}{% endif %}) in
+		property("{{ type.name }} is a {{ protocolName }}") <- forAll { (a: {{ type.name }}Of<{{ type.annotations.fixedTypesForPropertyBasedTests }}>{% if type.annotations.requiredContextForPropertyBasedTests %}, context: {{ type.annotations.requiredContextForPropertyBasedTests }}{% else %}{% endif %}) in
 			Law{% if type.annotations.requiredContextForPropertyBasedTests %}InContext{% else %}{% endif %}<{{ type.name }}<{{ type.annotations.fixedTypesForPropertyBasedTests }}>>.isNeutralToEmpty(a.get){% if type.annotations.requiredContextForPropertyBasedTests %}(context){% else %}{% endif %}
 		}
 {% else %}

--- a/Tests/AbstractTests/BoundedSemilatticeTests.generated.swift
+++ b/Tests/AbstractTests/BoundedSemilatticeTests.generated.swift
@@ -32,6 +32,12 @@ final class BoundedSemilatticeTests: XCTestCase {
 		}
 	}
 
+	func testOptionalBS() {
+		property("OptionalBS is a BoundedSemilattice") <- forAll { (a: OptionalBSOf<TestStructure>, b: OptionalBSOf<TestStructure>) in
+			Law<OptionalBS<TestStructure>>.isIdempotent(a.get,b.get)
+		}
+	}
+
 	func testOr() {
 		property("Or is a BoundedSemilattice") <- forAll { (a: Or, b: Or) in
 			Law<Or>.isIdempotent(a,b)
@@ -43,6 +49,7 @@ final class BoundedSemilatticeTests: XCTestCase {
 		("testFunctionBS",testFunctionBS),
 		("testMax",testMax),
 		("testMin",testMin),
+		("testOptionalBS",testOptionalBS),
 		("testOr",testOr),
 	]
 }

--- a/Tests/AbstractTests/CommutativeMonoidTests.generated.swift
+++ b/Tests/AbstractTests/CommutativeMonoidTests.generated.swift
@@ -50,6 +50,18 @@ final class CommutativeMonoidTests: XCTestCase {
 		}
 	}
 
+	func testOptionalBS() {
+		property("OptionalBS is a CommutativeMonoid") <- forAll { (a: OptionalBSOf<TestStructure>, b: OptionalBSOf<TestStructure>) in
+			Law<OptionalBS<TestStructure>>.isCommutative(a.get,b.get)
+		}
+	}
+
+	func testOptionalCM() {
+		property("OptionalCM is a CommutativeMonoid") <- forAll { (a: OptionalCMOf<TestStructure>, b: OptionalCMOf<TestStructure>) in
+			Law<OptionalCM<TestStructure>>.isCommutative(a.get,b.get)
+		}
+	}
+
 	func testOr() {
 		property("Or is a CommutativeMonoid") <- forAll { (a: Or, b: Or) in
 			Law<Or>.isCommutative(a,b)
@@ -64,6 +76,8 @@ final class CommutativeMonoidTests: XCTestCase {
 		("testMax",testMax),
 		("testMin",testMin),
 		("testMultiply",testMultiply),
+		("testOptionalBS",testOptionalBS),
+		("testOptionalCM",testOptionalCM),
 		("testOr",testOr),
 	]
 }

--- a/Tests/AbstractTests/MonoidTests.generated.swift
+++ b/Tests/AbstractTests/MonoidTests.generated.swift
@@ -9,7 +9,7 @@ import SwiftCheck
 final class MonoidTests: XCTestCase {
 
 	func testAdd() {
-	property("Add is a Monoid") <- forAll { (a: AddOf<Int>) in
+		property("Add is a Monoid") <- forAll { (a: AddOf<Int>) in
 			Law<Add<Int>>.isNeutralToEmpty(a.get)
 		}
 	}
@@ -20,74 +20,80 @@ final class MonoidTests: XCTestCase {
 		}
 	}
 
+	func testArrayEq() {
+		property("ArrayEq is a Monoid") <- forAll { (a: ArrayEqOf<TestStructure>) in
+			Law<ArrayEq<TestStructure>>.isNeutralToEmpty(a.get)
+		}
+	}
+
 	func testEndofunction() {
-	property("Endofunction is a Monoid") <- forAll { (a: EndofunctionOf<Int>, context: Int) in
+		property("Endofunction is a Monoid") <- forAll { (a: EndofunctionOf<Int>, context: Int) in
 			LawInContext<Endofunction<Int>>.isNeutralToEmpty(a.get)(context)
 		}
 	}
 
 	func testFirstM() {
-	property("FirstM is a Monoid") <- forAll { (a: FirstMOf<TestStructure>) in
+		property("FirstM is a Monoid") <- forAll { (a: FirstMOf<TestStructure>) in
 			Law<FirstM<TestStructure>>.isNeutralToEmpty(a.get)
 		}
 	}
 
 	func testFunctionBS() {
-	property("FunctionBS is a Monoid") <- forAll { (a: FunctionBSOf<Int,TestStructure>, context: Int) in
+		property("FunctionBS is a Monoid") <- forAll { (a: FunctionBSOf<Int,TestStructure>, context: Int) in
 			LawInContext<FunctionBS<Int,TestStructure>>.isNeutralToEmpty(a.get)(context)
 		}
 	}
 
 	func testFunctionCM() {
-	property("FunctionCM is a Monoid") <- forAll { (a: FunctionCMOf<Int,TestStructure>, context: Int) in
+		property("FunctionCM is a Monoid") <- forAll { (a: FunctionCMOf<Int,TestStructure>, context: Int) in
 			LawInContext<FunctionCM<Int,TestStructure>>.isNeutralToEmpty(a.get)(context)
 		}
 	}
 
 	func testFunctionM() {
-	property("FunctionM is a Monoid") <- forAll { (a: FunctionMOf<Int,TestStructure>, context: Int) in
+		property("FunctionM is a Monoid") <- forAll { (a: FunctionMOf<Int,TestStructure>, context: Int) in
 			LawInContext<FunctionM<Int,TestStructure>>.isNeutralToEmpty(a.get)(context)
 		}
 	}
 
 	func testLastM() {
-	property("LastM is a Monoid") <- forAll { (a: LastMOf<TestStructure>) in
+		property("LastM is a Monoid") <- forAll { (a: LastMOf<TestStructure>) in
 			Law<LastM<TestStructure>>.isNeutralToEmpty(a.get)
 		}
 	}
 
 	func testMax() {
-	property("Max is a Monoid") <- forAll { (a: MaxOf<Int>) in
+		property("Max is a Monoid") <- forAll { (a: MaxOf<Int>) in
 			Law<Max<Int>>.isNeutralToEmpty(a.get)
 		}
 	}
 
 	func testMin() {
-	property("Min is a Monoid") <- forAll { (a: MinOf<Int>) in
+		property("Min is a Monoid") <- forAll { (a: MinOf<Int>) in
 			Law<Min<Int>>.isNeutralToEmpty(a.get)
 		}
 	}
 
 	func testMultiply() {
-	property("Multiply is a Monoid") <- forAll { (a: MultiplyOf<Int>) in
+		property("Multiply is a Monoid") <- forAll { (a: MultiplyOf<Int>) in
 			Law<Multiply<Int>>.isNeutralToEmpty(a.get)
 		}
 	}
 
 	func testOptionalBS() {
-	property("OptionalBS is a Monoid") <- forAll { (a: OptionalBSOf<TestStructure>) in
+		property("OptionalBS is a Monoid") <- forAll { (a: OptionalBSOf<TestStructure>) in
 			Law<OptionalBS<TestStructure>>.isNeutralToEmpty(a.get)
 		}
 	}
 
 	func testOptionalCM() {
-	property("OptionalCM is a Monoid") <- forAll { (a: OptionalCMOf<TestStructure>) in
+		property("OptionalCM is a Monoid") <- forAll { (a: OptionalCMOf<TestStructure>) in
 			Law<OptionalCM<TestStructure>>.isNeutralToEmpty(a.get)
 		}
 	}
 
 	func testOptionalM() {
-	property("OptionalM is a Monoid") <- forAll { (a: OptionalMOf<TestStructure>) in
+		property("OptionalM is a Monoid") <- forAll { (a: OptionalMOf<TestStructure>) in
 			Law<OptionalM<TestStructure>>.isNeutralToEmpty(a.get)
 		}
 	}
@@ -113,6 +119,7 @@ final class MonoidTests: XCTestCase {
 	static var allTests = [
 		("testAdd",testAdd),
 		("testAnd",testAnd),
+		("testArrayEq",testArrayEq),
 		("testEndofunction",testEndofunction),
 		("testFirstM",testFirstM),
 		("testFunctionBS",testFunctionBS),

--- a/Tests/AbstractTests/MonoidTests.generated.swift
+++ b/Tests/AbstractTests/MonoidTests.generated.swift
@@ -104,6 +104,12 @@ final class MonoidTests: XCTestCase {
 		}
 	}
 
+	func testString() {
+		property("String is a Monoid") <- forAll { (a: String) in
+			Law<String>.isNeutralToEmpty(a)
+		}
+	}
+
 	static var allTests = [
 		("testAdd",testAdd),
 		("testAnd",testAnd),
@@ -121,5 +127,6 @@ final class MonoidTests: XCTestCase {
 		("testOptionalM",testOptionalM),
 		("testOr",testOr),
 		("testOrdering",testOrdering),
+		("testString",testString),
 	]
 }

--- a/Tests/AbstractTests/MonoidTests.generated.swift
+++ b/Tests/AbstractTests/MonoidTests.generated.swift
@@ -74,6 +74,24 @@ final class MonoidTests: XCTestCase {
 		}
 	}
 
+	func testOptionalBS() {
+	property("OptionalBS is a Monoid") <- forAll { (a: OptionalBSOf<TestStructure>) in
+			Law<OptionalBS<TestStructure>>.isNeutralToEmpty(a.get)
+		}
+	}
+
+	func testOptionalCM() {
+	property("OptionalCM is a Monoid") <- forAll { (a: OptionalCMOf<TestStructure>) in
+			Law<OptionalCM<TestStructure>>.isNeutralToEmpty(a.get)
+		}
+	}
+
+	func testOptionalM() {
+	property("OptionalM is a Monoid") <- forAll { (a: OptionalMOf<TestStructure>) in
+			Law<OptionalM<TestStructure>>.isNeutralToEmpty(a.get)
+		}
+	}
+
 	func testOr() {
 		property("Or is a Monoid") <- forAll { (a: Or) in
 			Law<Or>.isNeutralToEmpty(a)
@@ -98,6 +116,9 @@ final class MonoidTests: XCTestCase {
 		("testMax",testMax),
 		("testMin",testMin),
 		("testMultiply",testMultiply),
+		("testOptionalBS",testOptionalBS),
+		("testOptionalCM",testOptionalCM),
+		("testOptionalM",testOptionalM),
 		("testOr",testOr),
 		("testOrdering",testOrdering),
 	]

--- a/Tests/AbstractTests/SemigroupTests.generated.swift
+++ b/Tests/AbstractTests/SemigroupTests.generated.swift
@@ -92,6 +92,30 @@ final class SemigroupTests: XCTestCase {
 		}
 	}
 
+	func testOptionalBS() {
+		property("OptionalBS is a Semigroup") <- forAll { (a: OptionalBSOf<TestStructure>, b: OptionalBSOf<TestStructure>, c: OptionalBSOf<TestStructure>) in
+			Law<OptionalBS<TestStructure>>.isAssociative(a.get,b.get,c.get)
+		}
+	}
+
+	func testOptionalCM() {
+		property("OptionalCM is a Semigroup") <- forAll { (a: OptionalCMOf<TestStructure>, b: OptionalCMOf<TestStructure>, c: OptionalCMOf<TestStructure>) in
+			Law<OptionalCM<TestStructure>>.isAssociative(a.get,b.get,c.get)
+		}
+	}
+
+	func testOptionalM() {
+		property("OptionalM is a Semigroup") <- forAll { (a: OptionalMOf<TestStructure>, b: OptionalMOf<TestStructure>, c: OptionalMOf<TestStructure>) in
+			Law<OptionalM<TestStructure>>.isAssociative(a.get,b.get,c.get)
+		}
+	}
+
+	func testOptionalS() {
+		property("OptionalS is a Semigroup") <- forAll { (a: OptionalSOf<TestStructure>, b: OptionalSOf<TestStructure>, c: OptionalSOf<TestStructure>) in
+			Law<OptionalS<TestStructure>>.isAssociative(a.get,b.get,c.get)
+		}
+	}
+
 	func testOr() {
 		property("Or is a Semigroup") <- forAll { (a: Or, b: Or, c: Or) in
 			Law<Or>.isAssociative(a,b,c)
@@ -119,6 +143,10 @@ final class SemigroupTests: XCTestCase {
 		("testMax",testMax),
 		("testMin",testMin),
 		("testMultiply",testMultiply),
+		("testOptionalBS",testOptionalBS),
+		("testOptionalCM",testOptionalCM),
+		("testOptionalM",testOptionalM),
+		("testOptionalS",testOptionalS),
 		("testOr",testOr),
 		("testOrdering",testOrdering),
 	]

--- a/Tests/AbstractTests/SemigroupTests.generated.swift
+++ b/Tests/AbstractTests/SemigroupTests.generated.swift
@@ -128,6 +128,12 @@ final class SemigroupTests: XCTestCase {
 		}
 	}
 
+	func testString() {
+		property("String is a Semigroup") <- forAll { (a: String, b: String, c: String) in
+			Law<String>.isAssociative(a,b,c)
+		}
+	}
+
 	static var allTests = [
 		("testAdd",testAdd),
 		("testAnd",testAnd),
@@ -149,5 +155,6 @@ final class SemigroupTests: XCTestCase {
 		("testOptionalS",testOptionalS),
 		("testOr",testOr),
 		("testOrdering",testOrdering),
+		("testString",testString),
 	]
 }

--- a/Tests/AbstractTests/SemigroupTests.generated.swift
+++ b/Tests/AbstractTests/SemigroupTests.generated.swift
@@ -20,6 +20,12 @@ final class SemigroupTests: XCTestCase {
 		}
 	}
 
+	func testArrayEq() {
+		property("ArrayEq is a Semigroup") <- forAll { (a: ArrayEqOf<TestStructure>, b: ArrayEqOf<TestStructure>, c: ArrayEqOf<TestStructure>) in
+			Law<ArrayEq<TestStructure>>.isAssociative(a.get,b.get,c.get)
+		}
+	}
+
 	func testEndofunction() {
 		property("Endofunction is a Semigroup") <- forAll { (a: EndofunctionOf<Int>, b: EndofunctionOf<Int>, c: EndofunctionOf<Int>, context: Int) in
 			LawInContext<Endofunction<Int>>.isAssociative(a.get,b.get,c.get)(context)
@@ -137,6 +143,7 @@ final class SemigroupTests: XCTestCase {
 	static var allTests = [
 		("testAdd",testAdd),
 		("testAnd",testAnd),
+		("testArrayEq",testArrayEq),
 		("testEndofunction",testEndofunction),
 		("testFirst",testFirst),
 		("testFirstM",testFirstM),

--- a/Tests/AbstractTests/WrapperTests.generated.swift
+++ b/Tests/AbstractTests/WrapperTests.generated.swift
@@ -98,6 +98,30 @@ final class WrapperTests: XCTestCase {
 		}
 	}
 
+	func testOptionalBS() {
+		property("OptionalBS is a well-behaved Wrapper") <- forAll { (a: OptionalBSOf<TestStructure>) in
+			Law<OptionalBS<TestStructure>>.isWellBehavedWrapper(a.get)
+		}
+	}
+
+	func testOptionalCM() {
+		property("OptionalCM is a well-behaved Wrapper") <- forAll { (a: OptionalCMOf<TestStructure>) in
+			Law<OptionalCM<TestStructure>>.isWellBehavedWrapper(a.get)
+		}
+	}
+
+	func testOptionalM() {
+		property("OptionalM is a well-behaved Wrapper") <- forAll { (a: OptionalMOf<TestStructure>) in
+			Law<OptionalM<TestStructure>>.isWellBehavedWrapper(a.get)
+		}
+	}
+
+	func testOptionalS() {
+		property("OptionalS is a well-behaved Wrapper") <- forAll { (a: OptionalSOf<TestStructure>) in
+			Law<OptionalS<TestStructure>>.isWellBehavedWrapper(a.get)
+		}
+	}
+
 	func testOr() {
 		property("Or is a well-behaved Wrapper") <- forAll { (a: Or) in
 			Law<Or>.isWellBehavedWrapper(a)
@@ -126,6 +150,10 @@ final class WrapperTests: XCTestCase {
 		("testMax",testMax),
 		("testMin",testMin),
 		("testMultiply",testMultiply),
+		("testOptionalBS",testOptionalBS),
+		("testOptionalCM",testOptionalCM),
+		("testOptionalM",testOptionalM),
+		("testOptionalS",testOptionalS),
 		("testOr",testOr),
 		("testTropical",testTropical),
 	]

--- a/Tests/AbstractTests/WrapperTests.generated.swift
+++ b/Tests/AbstractTests/WrapperTests.generated.swift
@@ -20,6 +20,12 @@ final class WrapperTests: XCTestCase {
 		}
 	}
 
+	func testArrayEq() {
+		property("ArrayEq is a well-behaved Wrapper") <- forAll { (a: ArrayEqOf<TestStructure>) in
+			Law<ArrayEq<TestStructure>>.isWellBehavedWrapper(a.get)
+		}
+	}
+
 	func testEndofunction() {
 		property("Endofunction is a well-behaved Wrapper") <- forAll { (a: EndofunctionOf<Int>, context: Int) in
 			LawInContext<Endofunction<Int>>.isWellBehavedWrapper(a.get)(context)
@@ -137,6 +143,7 @@ final class WrapperTests: XCTestCase {
 	static var allTests = [
 		("testAdd",testAdd),
 		("testAnd",testAnd),
+		("testArrayEq",testArrayEq),
 		("testEndofunction",testEndofunction),
 		("testFirst",testFirst),
 		("testFirstM",testFirstM),

--- a/Tests/Utility/Arbitrary.generated.swift
+++ b/Tests/Utility/Arbitrary.generated.swift
@@ -154,6 +154,74 @@ struct MultiplyOf<T>: Arbitrary where T: Arbitrary & Multipliable {
     }
 }
 
+struct OptionalBSOf<T>: Arbitrary where T: Arbitrary & BoundedSemilattice & Equatable {
+    let get: OptionalBS<T>
+    init(_ get: OptionalBS<T>) {
+        self.get = get
+    }
+
+    public static var arbitrary: Gen<OptionalBSOf<T>> {
+        return Gen<OptionalBS<T>>
+            .compose {
+                OptionalBS<T>.init(
+                    unwrap: $0.generate(using: OptionalOf<T>.arbitrary.map { $0.getOptional })
+                )
+            }
+            .map(OptionalBSOf<T>.init)
+    }
+}
+
+struct OptionalCMOf<T>: Arbitrary where T: Arbitrary & CommutativeMonoid & Equatable {
+    let get: OptionalCM<T>
+    init(_ get: OptionalCM<T>) {
+        self.get = get
+    }
+
+    public static var arbitrary: Gen<OptionalCMOf<T>> {
+        return Gen<OptionalCM<T>>
+            .compose {
+                OptionalCM<T>.init(
+                    unwrap: $0.generate(using: OptionalOf<T>.arbitrary.map { $0.getOptional })
+                )
+            }
+            .map(OptionalCMOf<T>.init)
+    }
+}
+
+struct OptionalMOf<T>: Arbitrary where T: Arbitrary & Monoid & Equatable {
+    let get: OptionalM<T>
+    init(_ get: OptionalM<T>) {
+        self.get = get
+    }
+
+    public static var arbitrary: Gen<OptionalMOf<T>> {
+        return Gen<OptionalM<T>>
+            .compose {
+                OptionalM<T>.init(
+                    unwrap: $0.generate(using: OptionalOf<T>.arbitrary.map { $0.getOptional })
+                )
+            }
+            .map(OptionalMOf<T>.init)
+    }
+}
+
+struct OptionalSOf<T>: Arbitrary where T: Arbitrary & Semigroup & Equatable {
+    let get: OptionalS<T>
+    init(_ get: OptionalS<T>) {
+        self.get = get
+    }
+
+    public static var arbitrary: Gen<OptionalSOf<T>> {
+        return Gen<OptionalS<T>>
+            .compose {
+                OptionalS<T>.init(
+                    unwrap: $0.generate(using: OptionalOf<T>.arbitrary.map { $0.getOptional })
+                )
+            }
+            .map(OptionalSOf<T>.init)
+    }
+}
+
 extension Or: Arbitrary {
     public static var arbitrary: Gen<Or> {
         return Gen<Or>

--- a/Tests/Utility/Arbitrary.generated.swift
+++ b/Tests/Utility/Arbitrary.generated.swift
@@ -35,6 +35,23 @@ extension And: Arbitrary {
     }
 }
 
+struct ArrayEqOf<T>: Arbitrary where T: Arbitrary & Equatable {
+    let get: ArrayEq<T>
+    init(_ get: ArrayEq<T>) {
+        self.get = get
+    }
+
+    public static var arbitrary: Gen<ArrayEqOf<T>> {
+        return Gen<ArrayEq<T>>
+            .compose {
+                ArrayEq<T>.init(
+                    unwrap: $0.generate(using: ArrayOf<T>.arbitrary.map { $0.getArray })
+                )
+            }
+            .map(ArrayEqOf<T>.init)
+    }
+}
+
 struct FirstOf<T>: Arbitrary where T: Arbitrary & Equatable {
     let get: First<T>
     init(_ get: First<T>) {


### PR DESCRIPTION
I added the following things, that I found much needed in my real-world usage of the library:

- `String` now implements `Monoid` with the obvious concatenation operation;
- `OptionalS`,` OptionalM`, `OptionalCM` and `OptionalBS` types, for operating with Optionals in abstract context (this is similar to `FunctionS` et cetera, and it's going to go away when [SE-0143](https://github.com/apple/swift-evolution/blob/master/proposals/0143-conditional-conformances.md) is implemented);
- `ArrayEq` which is a wrapper for an `Array` with `Equatable` elements, that other than implementing `Equatable` itself, also implements `Monoid` with the obvious concatenation operation.

I also modified the Xcode project to make the folder with Stencil templates as a folder reference (instead of a group).