### PR TITLE
Add wrappers for function types

### DIFF
--- a/Sources/Abstract/BoundedSemilattice.swift
+++ b/Sources/Abstract/BoundedSemilattice.swift
@@ -63,6 +63,39 @@ public struct OptionalBS<T>: BoundedSemilattice, Wrapper, Equatable where T: Bou
 
 //: ------
 
+// sourcery: fixedTypesForPropertyBasedTests = "TestFunction"
+// sourcery: requiredContextForPropertyBasedTests = "String"
+// sourcery: arbitrary
+// sourcery: arbitraryGenericParameterProtocols = "BoundedSemilattice & EquatableInContext"
+public struct OptionalBSF<T>: BoundedSemilattice, Wrapper, EquatableInContext where T: BoundedSemilattice & EquatableInContext {
+	public typealias WrappedType = T?
+	public typealias Context = T.Context
+
+	public let unwrap: T?
+	public init(_ value: T?) {
+		self.unwrap = value
+	}
+
+	public static var empty: OptionalBSF<T> {
+		return .init(nil)
+	}
+
+	public static func <> (_ left: OptionalBSF, _ right: OptionalBSF) -> OptionalBSF {
+		switch (left.unwrap,right.unwrap) {
+		case (.some(let leftValue),.some(let rightValue)):
+			return .init(leftValue <> rightValue)
+		case (.some,_):
+			return left
+		case (_,.some):
+			return right
+		default:
+			return .init(nil)
+		}
+	}
+}
+
+//: ------
+
 extension Max: BoundedSemilattice {}
 
 //: ------

--- a/Sources/Abstract/CommutativeMonoid.swift
+++ b/Sources/Abstract/CommutativeMonoid.swift
@@ -63,6 +63,39 @@ public struct OptionalCM<T>: CommutativeMonoid, Wrapper, Equatable where T: Comm
 
 //: ------
 
+// sourcery: fixedTypesForPropertyBasedTests = "TestFunction"
+// sourcery: requiredContextForPropertyBasedTests = "String"
+// sourcery: arbitrary
+// sourcery: arbitraryGenericParameterProtocols = "CommutativeMonoid & EquatableInContext"
+public struct OptionalCMF<T>: CommutativeMonoid, Wrapper, EquatableInContext where T: CommutativeMonoid & EquatableInContext {
+	public typealias WrappedType = T?
+	public typealias Context = T.Context
+
+	public let unwrap: T?
+	public init(_ value: T?) {
+		self.unwrap = value
+	}
+
+	public static var empty: OptionalCMF<T> {
+		return .init(nil)
+	}
+
+	public static func <> (_ left: OptionalCMF, _ right: OptionalCMF) -> OptionalCMF {
+		switch (left.unwrap,right.unwrap) {
+		case (.some(let leftValue),.some(let rightValue)):
+			return .init(leftValue <> rightValue)
+		case (.some,_):
+			return left
+		case (_,.some):
+			return right
+		default:
+			return .init(nil)
+		}
+	}
+}
+
+//: ------
+
 extension Add: CommutativeMonoid {}
 
 //: ------

--- a/Sources/Abstract/Law.swift
+++ b/Sources/Abstract/Law.swift
@@ -21,3 +21,4 @@ public protocol EquatableInContext {
 }
 
 public enum LawInContext<Element: EquatableInContext> {}
+

--- a/Sources/Abstract/Monoid.swift
+++ b/Sources/Abstract/Monoid.swift
@@ -59,16 +59,36 @@ public struct ArrayEq<T>: Wrapper, Monoid, Equatable where T: Equatable {
 		self.unwrap = value
 	}
 
-	public static func == (left: ArrayEq, right: ArrayEq) -> Bool {
-		return left.unwrap == right.unwrap
-	}
-
 	public static var empty: ArrayEq<T> {
 		return .init([])
 	}
 
 	public static func <> (left: ArrayEq, right: ArrayEq) -> ArrayEq {
 		return ArrayEq.init(left.unwrap + right.unwrap)
+	}
+}
+
+//: ------
+
+// sourcery: fixedTypesForPropertyBasedTests = "TestFunction"
+// sourcery: requiredContextForPropertyBasedTests = "String"
+// sourcery: arbitrary
+// sourcery: arbitraryGenericParameterProtocols = "EquatableInContext"
+public struct ArrayEqF<T>: Wrapper, Monoid, EquatableInContext where T: EquatableInContext {
+	public typealias WrappedType = [T]
+	public typealias Context = T.Context
+
+	public let unwrap: [T]
+	public init(_ value: [T]) {
+		self.unwrap = value
+	}
+
+	public static var empty: ArrayEqF<T> {
+		return .init([])
+	}
+
+	public static func <> (left: ArrayEqF, right: ArrayEqF) -> ArrayEqF {
+		return ArrayEqF.init(left.unwrap + right.unwrap)
 	}
 }
 
@@ -85,15 +105,35 @@ public struct OptionalEq<T>: Wrapper, Monoid, Equatable where T: Equatable {
 		self.unwrap = value
 	}
 
-	public static func == (left: OptionalEq, right: OptionalEq) -> Bool {
-		return left.unwrap == right.unwrap
-	}
-
 	public static var empty: OptionalEq {
 		return .init(.none)
 	}
 
 	public static func <> (left: OptionalEq, right: OptionalEq) -> OptionalEq {
+		return .init(left.unwrap ?? right.unwrap)
+	}
+}
+
+//: ------
+
+// sourcery: fixedTypesForPropertyBasedTests = "TestFunction"
+// sourcery: requiredContextForPropertyBasedTests = "String"
+// sourcery: arbitrary
+// sourcery: arbitraryGenericParameterProtocols = "EquatableInContext"
+public struct OptionalEqF<T>: Wrapper, Monoid, EquatableInContext where T: EquatableInContext {
+	public typealias WrappedType = Optional<T>
+	public typealias Context = T.Context
+
+	public let unwrap: Optional<T>
+	public init(_ value: Optional<T>) {
+		self.unwrap = value
+	}
+
+	public static var empty: OptionalEqF {
+		return .init(.none)
+	}
+
+	public static func <> (left: OptionalEqF, right: OptionalEqF) -> OptionalEqF {
 		return .init(left.unwrap ?? right.unwrap)
 	}
 }
@@ -127,9 +167,38 @@ public struct OptionalM<T>: Monoid, Wrapper, Equatable where T: Semigroup & Equa
 			return .init(nil)
 		}
 	}
+}
 
-	public static func == (_ left: OptionalM, _ right: OptionalM) -> Bool {
-		return left.unwrap == right.unwrap
+//: ------
+
+// sourcery: fixedTypesForPropertyBasedTests = "TestFunction"
+// sourcery: requiredContextForPropertyBasedTests = "String"
+// sourcery: arbitrary
+// sourcery: arbitraryGenericParameterProtocols = "Semigroup & EquatableInContext"
+public struct OptionalMF<T>: Monoid, Wrapper, EquatableInContext where T: Semigroup & EquatableInContext {
+	public typealias WrappedType = T?
+	public typealias Context = T.Context
+
+	public let unwrap: T?
+	public init(_ value: T?) {
+		self.unwrap = value
+	}
+
+	public static var empty: OptionalMF<T> {
+		return .init(nil)
+	}
+
+	public static func <> (_ left: OptionalMF, _ right: OptionalMF) -> OptionalMF {
+		switch (left.unwrap,right.unwrap) {
+		case (.some(let leftValue),.some(let rightValue)):
+			return .init(leftValue <> rightValue)
+		case (.some,_):
+			return left
+		case (_,.some):
+			return right
+		default:
+			return .init(nil)
+		}
 	}
 }
 
@@ -190,7 +259,7 @@ extension Or: Monoid {
 // sourcery: fixedTypesForPropertyBasedTests = "TestStructure"
 // sourcery: arbitrary
 // sourcery: arbitraryGenericParameterProtocols = "Monoid & Equatable"
-public struct FirstM<A: Monoid & Equatable>: Wrapper, Monoid, Equatable {
+public struct FirstM<A>: Wrapper, Monoid, Equatable where A: Monoid & Equatable {
 	public typealias WrappedType = A
 
 	public let unwrap: A

--- a/Sources/Abstract/Semigroup.swift
+++ b/Sources/Abstract/Semigroup.swift
@@ -58,15 +58,9 @@ public struct OptionalS<T>: Semigroup, Wrapper, Equatable where T: Semigroup & E
 			return .init(nil)
 		}
 	}
-
-	public static func == (_ left: OptionalS, _ right: OptionalS) -> Bool {
-		return left.unwrap == right.unwrap
-	}
 }
 
 //: ------
-
-//: `OptionalSF` is like `OptionalS` but wraps a `Function` type with `Semigroup` conformance
 
 // sourcery: fixedTypesForPropertyBasedTests = "TestFunction"
 // sourcery: requiredContextForPropertyBasedTests = "String"
@@ -92,17 +86,6 @@ public struct OptionalSF<T>: Semigroup, Wrapper, EquatableInContext where T: Sem
 			return right
 		default:
 			return .init(nil)
-		}
-	}
-
-	public static func == (_ left: OptionalSF, _ right: OptionalSF) -> (Context) -> Bool {
-		switch (left.unwrap,right.unwrap) {
-		case (.some(let leftUnwrap),.some(let rightUnwrap)):
-			return leftUnwrap == rightUnwrap
-		case (.none,.none):
-			return { _ in true }
-		default:
-			return { _ in false }
 		}
 	}
 }

--- a/Sources/Abstract/Semigroup.swift
+++ b/Sources/Abstract/Semigroup.swift
@@ -64,6 +64,48 @@ public struct OptionalS<T>: Semigroup, Wrapper, Equatable where T: Semigroup & E
 	}
 }
 
+//: ------
+
+//: `OptionalSF` is like `OptionalS` but wraps a `Function` type with `Semigroup` conformance
+
+// sourcery: fixedTypesForPropertyBasedTests = "TestFunction"
+// sourcery: requiredContextForPropertyBasedTests = "String"
+// sourcery: arbitrary
+// sourcery: arbitraryGenericParameterProtocols = "Semigroup & EquatableInContext"
+public struct OptionalSF<T>: Semigroup, Wrapper, EquatableInContext where T: Semigroup & EquatableInContext {
+	public typealias WrappedType = T?
+	public typealias Context = T.Context
+
+	public let unwrap: WrappedType
+
+	public init(_ value: WrappedType) {
+		self.unwrap = value
+	}
+
+	public static func <> (_ left: OptionalSF, _ right: OptionalSF) -> OptionalSF {
+		switch (left.unwrap,right.unwrap) {
+		case (.some(let leftValue),.some(let rightValue)):
+			return .init(leftValue <> rightValue)
+		case (.some,_):
+			return left
+		case (_,.some):
+			return right
+		default:
+			return .init(nil)
+		}
+	}
+
+	public static func == (_ left: OptionalSF, _ right: OptionalSF) -> (Context) -> Bool {
+		switch (left.unwrap,right.unwrap) {
+		case (.some(let leftUnwrap),.some(let rightUnwrap)):
+			return leftUnwrap == rightUnwrap
+		case (.none,.none):
+			return { _ in true }
+		default:
+			return { _ in false }
+		}
+	}
+}
 
 //: ------
 
@@ -206,10 +248,31 @@ public struct First<A: Equatable>: Wrapper, Semigroup, Equatable {
 
 //: ------
 
+// sourcery: fixedTypesForPropertyBasedTests = "TestFunction"
+// sourcery: requiredContextForPropertyBasedTests = "String"
+// sourcery: arbitrary
+// sourcery: arbitraryGenericParameterProtocols = "EquatableInContext"
+public struct FirstF<A>: Wrapper, Semigroup, EquatableInContext where A: EquatableInContext {
+	public typealias WrappedType = A
+	public typealias Context = A.Context
+
+	public let unwrap: WrappedType
+
+	public init(_ value: WrappedType) {
+		self.unwrap = value
+	}
+
+	public static func <> (left: FirstF, right: FirstF) -> FirstF {
+		return left
+	}
+}
+
+//: ------
+
 // sourcery: fixedTypesForPropertyBasedTests = "Int"
 // sourcery: arbitrary
 // sourcery: arbitraryGenericParameterProtocols = "Equatable"
-public struct Last<A: Equatable>: Wrapper, Semigroup, Equatable {
+public struct Last<A>: Wrapper, Semigroup, Equatable where A: Equatable {
     public typealias WrappedType = A
     
     public let unwrap: A
@@ -221,6 +284,27 @@ public struct Last<A: Equatable>: Wrapper, Semigroup, Equatable {
     public static func <> (left: Last, right: Last) -> Last {
         return right
     }
+}
+
+//: ------
+
+// sourcery: fixedTypesForPropertyBasedTests = "TestFunction"
+// sourcery: requiredContextForPropertyBasedTests = "String"
+// sourcery: arbitrary
+// sourcery: arbitraryGenericParameterProtocols = "EquatableInContext"
+public struct LastF<A>: Wrapper, Semigroup, EquatableInContext where A: EquatableInContext {
+	public typealias WrappedType = A
+	public typealias Context = A.Context
+
+	public let unwrap: A
+
+	public init(_ value: A) {
+		self.unwrap = value
+	}
+
+	public static func <> (left: LastF, right: LastF) -> LastF {
+		return right
+	}
 }
 
 //: ------

--- a/Sources/Abstract/Wrapper.swift
+++ b/Sources/Abstract/Wrapper.swift
@@ -37,11 +37,17 @@ extension LawInContext where Element: Wrapper {
 }
 
 /*:
-If the `WrappedType` element is `Equatable`, we can define the static `==` function for a `Wrapper` (unfortunately, the `Equatable` conformance must be declared explicitly for every wrapper).
+If the `WrappedType` element is `Equatable` or `EquatableInContext`, we can define the static `==` function for a `Wrapper` (unfortunately, the `Equatable` or `EquatableInContext` conformance must be declared explicitly for every wrapper).
 */
 
 extension Wrapper where WrappedType: Equatable {
 	public static func == (left: Self, right: Self) -> Bool {
+		return left.unwrap == right.unwrap
+	}
+}
+
+extension Wrapper where WrappedType: EquatableInContext {
+	public static func == (left: Self, right: Self) -> (WrappedType.Context) -> Bool {
 		return left.unwrap == right.unwrap
 	}
 }

--- a/Tests/AbstractTests/BoundedSemilatticeTests.generated.swift
+++ b/Tests/AbstractTests/BoundedSemilatticeTests.generated.swift
@@ -38,6 +38,12 @@ final class BoundedSemilatticeTests: XCTestCase {
 		}
 	}
 
+	func testOptionalBSF() {
+		property("OptionalBSF is a BoundedSemilattice") <- forAll { (a: OptionalBSFOf<TestFunction>, b: OptionalBSFOf<TestFunction>, context: String) in
+			LawInContext<OptionalBSF<TestFunction>>.isIdempotent(a.get,b.get)(context)
+		}
+	}
+
 	func testOr() {
 		property("Or is a BoundedSemilattice") <- forAll { (a: Or, b: Or) in
 			Law<Or>.isIdempotent(a,b)
@@ -50,6 +56,7 @@ final class BoundedSemilatticeTests: XCTestCase {
 		("testMax",testMax),
 		("testMin",testMin),
 		("testOptionalBS",testOptionalBS),
+		("testOptionalBSF",testOptionalBSF),
 		("testOr",testOr),
 	]
 }

--- a/Tests/AbstractTests/CommutativeMonoidTests.generated.swift
+++ b/Tests/AbstractTests/CommutativeMonoidTests.generated.swift
@@ -56,6 +56,12 @@ final class CommutativeMonoidTests: XCTestCase {
 		}
 	}
 
+	func testOptionalBSF() {
+		property("OptionalBSF is a CommutativeMonoid") <- forAll { (a: OptionalBSFOf<TestFunction>, b: OptionalBSFOf<TestFunction>, context: String) in
+			LawInContext<OptionalBSF<TestFunction>>.isCommutative(a.get,b.get)(context)
+		}
+	}
+
 	func testOptionalCM() {
 		property("OptionalCM is a CommutativeMonoid") <- forAll { (a: OptionalCMOf<TestStructure>, b: OptionalCMOf<TestStructure>) in
 			Law<OptionalCM<TestStructure>>.isCommutative(a.get,b.get)
@@ -83,6 +89,7 @@ final class CommutativeMonoidTests: XCTestCase {
 		("testMin",testMin),
 		("testMultiply",testMultiply),
 		("testOptionalBS",testOptionalBS),
+		("testOptionalBSF",testOptionalBSF),
 		("testOptionalCM",testOptionalCM),
 		("testOptionalCMF",testOptionalCMF),
 		("testOr",testOr),

--- a/Tests/AbstractTests/CommutativeMonoidTests.generated.swift
+++ b/Tests/AbstractTests/CommutativeMonoidTests.generated.swift
@@ -62,6 +62,12 @@ final class CommutativeMonoidTests: XCTestCase {
 		}
 	}
 
+	func testOptionalCMF() {
+		property("OptionalCMF is a CommutativeMonoid") <- forAll { (a: OptionalCMFOf<TestFunction>, b: OptionalCMFOf<TestFunction>, context: String) in
+			LawInContext<OptionalCMF<TestFunction>>.isCommutative(a.get,b.get)(context)
+		}
+	}
+
 	func testOr() {
 		property("Or is a CommutativeMonoid") <- forAll { (a: Or, b: Or) in
 			Law<Or>.isCommutative(a,b)
@@ -78,6 +84,7 @@ final class CommutativeMonoidTests: XCTestCase {
 		("testMultiply",testMultiply),
 		("testOptionalBS",testOptionalBS),
 		("testOptionalCM",testOptionalCM),
+		("testOptionalCMF",testOptionalCMF),
 		("testOr",testOr),
 	]
 }

--- a/Tests/AbstractTests/MonoidTests.generated.swift
+++ b/Tests/AbstractTests/MonoidTests.generated.swift
@@ -98,6 +98,12 @@ final class MonoidTests: XCTestCase {
 		}
 	}
 
+	func testOptionalCMF() {
+		property("OptionalCMF is a Monoid") <- forAll { (a: OptionalCMFOf<TestFunction>, context: String) in
+			LawInContext<OptionalCMF<TestFunction>>.isNeutralToEmpty(a.get)(context)
+		}
+	}
+
 	func testOptionalEq() {
 		property("OptionalEq is a Monoid") <- forAll { (a: OptionalEqOf<TestStructure>) in
 			Law<OptionalEq<TestStructure>>.isNeutralToEmpty(a.get)
@@ -156,6 +162,7 @@ final class MonoidTests: XCTestCase {
 		("testMultiply",testMultiply),
 		("testOptionalBS",testOptionalBS),
 		("testOptionalCM",testOptionalCM),
+		("testOptionalCMF",testOptionalCMF),
 		("testOptionalEq",testOptionalEq),
 		("testOptionalEqF",testOptionalEqF),
 		("testOptionalM",testOptionalM),

--- a/Tests/AbstractTests/MonoidTests.generated.swift
+++ b/Tests/AbstractTests/MonoidTests.generated.swift
@@ -92,6 +92,12 @@ final class MonoidTests: XCTestCase {
 		}
 	}
 
+	func testOptionalBSF() {
+		property("OptionalBSF is a Monoid") <- forAll { (a: OptionalBSFOf<TestFunction>, context: String) in
+			LawInContext<OptionalBSF<TestFunction>>.isNeutralToEmpty(a.get)(context)
+		}
+	}
+
 	func testOptionalCM() {
 		property("OptionalCM is a Monoid") <- forAll { (a: OptionalCMOf<TestStructure>) in
 			Law<OptionalCM<TestStructure>>.isNeutralToEmpty(a.get)
@@ -161,6 +167,7 @@ final class MonoidTests: XCTestCase {
 		("testMin",testMin),
 		("testMultiply",testMultiply),
 		("testOptionalBS",testOptionalBS),
+		("testOptionalBSF",testOptionalBSF),
 		("testOptionalCM",testOptionalCM),
 		("testOptionalCMF",testOptionalCMF),
 		("testOptionalEq",testOptionalEq),

--- a/Tests/AbstractTests/MonoidTests.generated.swift
+++ b/Tests/AbstractTests/MonoidTests.generated.swift
@@ -26,6 +26,12 @@ final class MonoidTests: XCTestCase {
 		}
 	}
 
+	func testArrayEqF() {
+		property("ArrayEqF is a Monoid") <- forAll { (a: ArrayEqFOf<TestFunction>, context: String) in
+			LawInContext<ArrayEqF<TestFunction>>.isNeutralToEmpty(a.get)(context)
+		}
+	}
+
 	func testEndofunction() {
 		property("Endofunction is a Monoid") <- forAll { (a: EndofunctionOf<Int>, context: Int) in
 			LawInContext<Endofunction<Int>>.isNeutralToEmpty(a.get)(context)
@@ -98,9 +104,21 @@ final class MonoidTests: XCTestCase {
 		}
 	}
 
+	func testOptionalEqF() {
+		property("OptionalEqF is a Monoid") <- forAll { (a: OptionalEqFOf<TestFunction>, context: String) in
+			LawInContext<OptionalEqF<TestFunction>>.isNeutralToEmpty(a.get)(context)
+		}
+	}
+
 	func testOptionalM() {
 		property("OptionalM is a Monoid") <- forAll { (a: OptionalMOf<TestStructure>) in
 			Law<OptionalM<TestStructure>>.isNeutralToEmpty(a.get)
+		}
+	}
+
+	func testOptionalMF() {
+		property("OptionalMF is a Monoid") <- forAll { (a: OptionalMFOf<TestFunction>, context: String) in
+			LawInContext<OptionalMF<TestFunction>>.isNeutralToEmpty(a.get)(context)
 		}
 	}
 
@@ -126,6 +144,7 @@ final class MonoidTests: XCTestCase {
 		("testAdd",testAdd),
 		("testAnd",testAnd),
 		("testArrayEq",testArrayEq),
+		("testArrayEqF",testArrayEqF),
 		("testEndofunction",testEndofunction),
 		("testFirstM",testFirstM),
 		("testFunctionBS",testFunctionBS),
@@ -138,7 +157,9 @@ final class MonoidTests: XCTestCase {
 		("testOptionalBS",testOptionalBS),
 		("testOptionalCM",testOptionalCM),
 		("testOptionalEq",testOptionalEq),
+		("testOptionalEqF",testOptionalEqF),
 		("testOptionalM",testOptionalM),
+		("testOptionalMF",testOptionalMF),
 		("testOr",testOr),
 		("testOrdering",testOrdering),
 		("testString",testString),

--- a/Tests/AbstractTests/SemigroupTests.generated.swift
+++ b/Tests/AbstractTests/SemigroupTests.generated.swift
@@ -122,6 +122,12 @@ final class SemigroupTests: XCTestCase {
 		}
 	}
 
+	func testOptionalBSF() {
+		property("OptionalBSF is a Semigroup") <- forAll { (a: OptionalBSFOf<TestFunction>, b: OptionalBSFOf<TestFunction>, c: OptionalBSFOf<TestFunction>, context: String) in
+			LawInContext<OptionalBSF<TestFunction>>.isAssociative(a.get,b.get,c.get)(context)
+		}
+	}
+
 	func testOptionalCM() {
 		property("OptionalCM is a Semigroup") <- forAll { (a: OptionalCMOf<TestStructure>, b: OptionalCMOf<TestStructure>, c: OptionalCMOf<TestStructure>) in
 			Law<OptionalCM<TestStructure>>.isAssociative(a.get,b.get,c.get)
@@ -208,6 +214,7 @@ final class SemigroupTests: XCTestCase {
 		("testMin",testMin),
 		("testMultiply",testMultiply),
 		("testOptionalBS",testOptionalBS),
+		("testOptionalBSF",testOptionalBSF),
 		("testOptionalCM",testOptionalCM),
 		("testOptionalCMF",testOptionalCMF),
 		("testOptionalEq",testOptionalEq),

--- a/Tests/AbstractTests/SemigroupTests.generated.swift
+++ b/Tests/AbstractTests/SemigroupTests.generated.swift
@@ -26,6 +26,12 @@ final class SemigroupTests: XCTestCase {
 		}
 	}
 
+	func testArrayEqF() {
+		property("ArrayEqF is a Semigroup") <- forAll { (a: ArrayEqFOf<TestFunction>, b: ArrayEqFOf<TestFunction>, c: ArrayEqFOf<TestFunction>, context: String) in
+			LawInContext<ArrayEqF<TestFunction>>.isAssociative(a.get,b.get,c.get)(context)
+		}
+	}
+
 	func testEndofunction() {
 		property("Endofunction is a Semigroup") <- forAll { (a: EndofunctionOf<Int>, b: EndofunctionOf<Int>, c: EndofunctionOf<Int>, context: Int) in
 			LawInContext<Endofunction<Int>>.isAssociative(a.get,b.get,c.get)(context)
@@ -128,9 +134,21 @@ final class SemigroupTests: XCTestCase {
 		}
 	}
 
+	func testOptionalEqF() {
+		property("OptionalEqF is a Semigroup") <- forAll { (a: OptionalEqFOf<TestFunction>, b: OptionalEqFOf<TestFunction>, c: OptionalEqFOf<TestFunction>, context: String) in
+			LawInContext<OptionalEqF<TestFunction>>.isAssociative(a.get,b.get,c.get)(context)
+		}
+	}
+
 	func testOptionalM() {
 		property("OptionalM is a Semigroup") <- forAll { (a: OptionalMOf<TestStructure>, b: OptionalMOf<TestStructure>, c: OptionalMOf<TestStructure>) in
 			Law<OptionalM<TestStructure>>.isAssociative(a.get,b.get,c.get)
+		}
+	}
+
+	func testOptionalMF() {
+		property("OptionalMF is a Semigroup") <- forAll { (a: OptionalMFOf<TestFunction>, b: OptionalMFOf<TestFunction>, c: OptionalMFOf<TestFunction>, context: String) in
+			LawInContext<OptionalMF<TestFunction>>.isAssociative(a.get,b.get,c.get)(context)
 		}
 	}
 
@@ -168,6 +186,7 @@ final class SemigroupTests: XCTestCase {
 		("testAdd",testAdd),
 		("testAnd",testAnd),
 		("testArrayEq",testArrayEq),
+		("testArrayEqF",testArrayEqF),
 		("testEndofunction",testEndofunction),
 		("testFirst",testFirst),
 		("testFirstF",testFirstF),
@@ -185,7 +204,9 @@ final class SemigroupTests: XCTestCase {
 		("testOptionalBS",testOptionalBS),
 		("testOptionalCM",testOptionalCM),
 		("testOptionalEq",testOptionalEq),
+		("testOptionalEqF",testOptionalEqF),
 		("testOptionalM",testOptionalM),
+		("testOptionalMF",testOptionalMF),
 		("testOptionalS",testOptionalS),
 		("testOptionalSF",testOptionalSF),
 		("testOr",testOr),

--- a/Tests/AbstractTests/SemigroupTests.generated.swift
+++ b/Tests/AbstractTests/SemigroupTests.generated.swift
@@ -38,6 +38,12 @@ final class SemigroupTests: XCTestCase {
 		}
 	}
 
+	func testFirstF() {
+		property("FirstF is a Semigroup") <- forAll { (a: FirstFOf<TestFunction>, b: FirstFOf<TestFunction>, c: FirstFOf<TestFunction>, context: String) in
+			LawInContext<FirstF<TestFunction>>.isAssociative(a.get,b.get,c.get)(context)
+		}
+	}
+
 	func testFirstM() {
 		property("FirstM is a Semigroup") <- forAll { (a: FirstMOf<TestStructure>, b: FirstMOf<TestStructure>, c: FirstMOf<TestStructure>) in
 			Law<FirstM<TestStructure>>.isAssociative(a.get,b.get,c.get)
@@ -71,6 +77,12 @@ final class SemigroupTests: XCTestCase {
 	func testLast() {
 		property("Last is a Semigroup") <- forAll { (a: LastOf<Int>, b: LastOf<Int>, c: LastOf<Int>) in
 			Law<Last<Int>>.isAssociative(a.get,b.get,c.get)
+		}
+	}
+
+	func testLastF() {
+		property("LastF is a Semigroup") <- forAll { (a: LastFOf<TestFunction>, b: LastFOf<TestFunction>, c: LastFOf<TestFunction>, context: String) in
+			LawInContext<LastF<TestFunction>>.isAssociative(a.get,b.get,c.get)(context)
 		}
 	}
 
@@ -128,6 +140,12 @@ final class SemigroupTests: XCTestCase {
 		}
 	}
 
+	func testOptionalSF() {
+		property("OptionalSF is a Semigroup") <- forAll { (a: OptionalSFOf<TestFunction>, b: OptionalSFOf<TestFunction>, c: OptionalSFOf<TestFunction>, context: String) in
+			LawInContext<OptionalSF<TestFunction>>.isAssociative(a.get,b.get,c.get)(context)
+		}
+	}
+
 	func testOr() {
 		property("Or is a Semigroup") <- forAll { (a: Or, b: Or, c: Or) in
 			Law<Or>.isAssociative(a,b,c)
@@ -152,12 +170,14 @@ final class SemigroupTests: XCTestCase {
 		("testArrayEq",testArrayEq),
 		("testEndofunction",testEndofunction),
 		("testFirst",testFirst),
+		("testFirstF",testFirstF),
 		("testFirstM",testFirstM),
 		("testFunctionBS",testFunctionBS),
 		("testFunctionCM",testFunctionCM),
 		("testFunctionM",testFunctionM),
 		("testFunctionS",testFunctionS),
 		("testLast",testLast),
+		("testLastF",testLastF),
 		("testLastM",testLastM),
 		("testMax",testMax),
 		("testMin",testMin),
@@ -167,6 +187,7 @@ final class SemigroupTests: XCTestCase {
 		("testOptionalEq",testOptionalEq),
 		("testOptionalM",testOptionalM),
 		("testOptionalS",testOptionalS),
+		("testOptionalSF",testOptionalSF),
 		("testOr",testOr),
 		("testOrdering",testOrdering),
 		("testString",testString),

--- a/Tests/AbstractTests/SemigroupTests.generated.swift
+++ b/Tests/AbstractTests/SemigroupTests.generated.swift
@@ -128,6 +128,12 @@ final class SemigroupTests: XCTestCase {
 		}
 	}
 
+	func testOptionalCMF() {
+		property("OptionalCMF is a Semigroup") <- forAll { (a: OptionalCMFOf<TestFunction>, b: OptionalCMFOf<TestFunction>, c: OptionalCMFOf<TestFunction>, context: String) in
+			LawInContext<OptionalCMF<TestFunction>>.isAssociative(a.get,b.get,c.get)(context)
+		}
+	}
+
 	func testOptionalEq() {
 		property("OptionalEq is a Semigroup") <- forAll { (a: OptionalEqOf<TestStructure>, b: OptionalEqOf<TestStructure>, c: OptionalEqOf<TestStructure>) in
 			Law<OptionalEq<TestStructure>>.isAssociative(a.get,b.get,c.get)
@@ -203,6 +209,7 @@ final class SemigroupTests: XCTestCase {
 		("testMultiply",testMultiply),
 		("testOptionalBS",testOptionalBS),
 		("testOptionalCM",testOptionalCM),
+		("testOptionalCMF",testOptionalCMF),
 		("testOptionalEq",testOptionalEq),
 		("testOptionalEqF",testOptionalEqF),
 		("testOptionalM",testOptionalM),

--- a/Tests/AbstractTests/WrapperTests.generated.swift
+++ b/Tests/AbstractTests/WrapperTests.generated.swift
@@ -134,6 +134,12 @@ final class WrapperTests: XCTestCase {
 		}
 	}
 
+	func testOptionalCMF() {
+		property("OptionalCMF is a well-behaved Wrapper") <- forAll { (a: OptionalCMFOf<TestFunction>, context: String) in
+			LawInContext<OptionalCMF<TestFunction>>.isWellBehavedWrapper(a.get)(context)
+		}
+	}
+
 	func testOptionalEq() {
 		property("OptionalEq is a well-behaved Wrapper") <- forAll { (a: OptionalEqOf<TestStructure>) in
 			Law<OptionalEq<TestStructure>>.isWellBehavedWrapper(a.get)
@@ -204,6 +210,7 @@ final class WrapperTests: XCTestCase {
 		("testMultiply",testMultiply),
 		("testOptionalBS",testOptionalBS),
 		("testOptionalCM",testOptionalCM),
+		("testOptionalCMF",testOptionalCMF),
 		("testOptionalEq",testOptionalEq),
 		("testOptionalEqF",testOptionalEqF),
 		("testOptionalM",testOptionalM),

--- a/Tests/AbstractTests/WrapperTests.generated.swift
+++ b/Tests/AbstractTests/WrapperTests.generated.swift
@@ -38,6 +38,12 @@ final class WrapperTests: XCTestCase {
 		}
 	}
 
+	func testFirstF() {
+		property("FirstF is a well-behaved Wrapper") <- forAll { (a: FirstFOf<TestFunction>, context: String) in
+			LawInContext<FirstF<TestFunction>>.isWellBehavedWrapper(a.get)(context)
+		}
+	}
+
 	func testFirstM() {
 		property("FirstM is a well-behaved Wrapper") <- forAll { (a: FirstMOf<TestStructure>) in
 			Law<FirstM<TestStructure>>.isWellBehavedWrapper(a.get)
@@ -77,6 +83,12 @@ final class WrapperTests: XCTestCase {
 	func testLast() {
 		property("Last is a well-behaved Wrapper") <- forAll { (a: LastOf<Int>) in
 			Law<Last<Int>>.isWellBehavedWrapper(a.get)
+		}
+	}
+
+	func testLastF() {
+		property("LastF is a well-behaved Wrapper") <- forAll { (a: LastFOf<TestFunction>, context: String) in
+			LawInContext<LastF<TestFunction>>.isWellBehavedWrapper(a.get)(context)
 		}
 	}
 
@@ -134,6 +146,12 @@ final class WrapperTests: XCTestCase {
 		}
 	}
 
+	func testOptionalSF() {
+		property("OptionalSF is a well-behaved Wrapper") <- forAll { (a: OptionalSFOf<TestFunction>, context: String) in
+			LawInContext<OptionalSF<TestFunction>>.isWellBehavedWrapper(a.get)(context)
+		}
+	}
+
 	func testOr() {
 		property("Or is a well-behaved Wrapper") <- forAll { (a: Or) in
 			Law<Or>.isWellBehavedWrapper(a)
@@ -152,6 +170,7 @@ final class WrapperTests: XCTestCase {
 		("testArrayEq",testArrayEq),
 		("testEndofunction",testEndofunction),
 		("testFirst",testFirst),
+		("testFirstF",testFirstF),
 		("testFirstM",testFirstM),
 		("testFunctionBS",testFunctionBS),
 		("testFunctionCM",testFunctionCM),
@@ -159,6 +178,7 @@ final class WrapperTests: XCTestCase {
 		("testFunctionS",testFunctionS),
 		("testFunctionSR",testFunctionSR),
 		("testLast",testLast),
+		("testLastF",testLastF),
 		("testLastM",testLastM),
 		("testMax",testMax),
 		("testMin",testMin),
@@ -168,6 +188,7 @@ final class WrapperTests: XCTestCase {
 		("testOptionalEq",testOptionalEq),
 		("testOptionalM",testOptionalM),
 		("testOptionalS",testOptionalS),
+		("testOptionalSF",testOptionalSF),
 		("testOr",testOr),
 		("testTropical",testTropical),
 	]

--- a/Tests/AbstractTests/WrapperTests.generated.swift
+++ b/Tests/AbstractTests/WrapperTests.generated.swift
@@ -26,6 +26,12 @@ final class WrapperTests: XCTestCase {
 		}
 	}
 
+	func testArrayEqF() {
+		property("ArrayEqF is a well-behaved Wrapper") <- forAll { (a: ArrayEqFOf<TestFunction>, context: String) in
+			LawInContext<ArrayEqF<TestFunction>>.isWellBehavedWrapper(a.get)(context)
+		}
+	}
+
 	func testEndofunction() {
 		property("Endofunction is a well-behaved Wrapper") <- forAll { (a: EndofunctionOf<Int>, context: Int) in
 			LawInContext<Endofunction<Int>>.isWellBehavedWrapper(a.get)(context)
@@ -134,9 +140,21 @@ final class WrapperTests: XCTestCase {
 		}
 	}
 
+	func testOptionalEqF() {
+		property("OptionalEqF is a well-behaved Wrapper") <- forAll { (a: OptionalEqFOf<TestFunction>, context: String) in
+			LawInContext<OptionalEqF<TestFunction>>.isWellBehavedWrapper(a.get)(context)
+		}
+	}
+
 	func testOptionalM() {
 		property("OptionalM is a well-behaved Wrapper") <- forAll { (a: OptionalMOf<TestStructure>) in
 			Law<OptionalM<TestStructure>>.isWellBehavedWrapper(a.get)
+		}
+	}
+
+	func testOptionalMF() {
+		property("OptionalMF is a well-behaved Wrapper") <- forAll { (a: OptionalMFOf<TestFunction>, context: String) in
+			LawInContext<OptionalMF<TestFunction>>.isWellBehavedWrapper(a.get)(context)
 		}
 	}
 
@@ -168,6 +186,7 @@ final class WrapperTests: XCTestCase {
 		("testAdd",testAdd),
 		("testAnd",testAnd),
 		("testArrayEq",testArrayEq),
+		("testArrayEqF",testArrayEqF),
 		("testEndofunction",testEndofunction),
 		("testFirst",testFirst),
 		("testFirstF",testFirstF),
@@ -186,7 +205,9 @@ final class WrapperTests: XCTestCase {
 		("testOptionalBS",testOptionalBS),
 		("testOptionalCM",testOptionalCM),
 		("testOptionalEq",testOptionalEq),
+		("testOptionalEqF",testOptionalEqF),
 		("testOptionalM",testOptionalM),
+		("testOptionalMF",testOptionalMF),
 		("testOptionalS",testOptionalS),
 		("testOptionalSF",testOptionalSF),
 		("testOr",testOr),

--- a/Tests/AbstractTests/WrapperTests.generated.swift
+++ b/Tests/AbstractTests/WrapperTests.generated.swift
@@ -128,6 +128,12 @@ final class WrapperTests: XCTestCase {
 		}
 	}
 
+	func testOptionalBSF() {
+		property("OptionalBSF is a well-behaved Wrapper") <- forAll { (a: OptionalBSFOf<TestFunction>, context: String) in
+			LawInContext<OptionalBSF<TestFunction>>.isWellBehavedWrapper(a.get)(context)
+		}
+	}
+
 	func testOptionalCM() {
 		property("OptionalCM is a well-behaved Wrapper") <- forAll { (a: OptionalCMOf<TestStructure>) in
 			Law<OptionalCM<TestStructure>>.isWellBehavedWrapper(a.get)
@@ -209,6 +215,7 @@ final class WrapperTests: XCTestCase {
 		("testMin",testMin),
 		("testMultiply",testMultiply),
 		("testOptionalBS",testOptionalBS),
+		("testOptionalBSF",testOptionalBSF),
 		("testOptionalCM",testOptionalCM),
 		("testOptionalCMF",testOptionalCMF),
 		("testOptionalEq",testOptionalEq),

--- a/Tests/Utility/Arbitrary.generated.swift
+++ b/Tests/Utility/Arbitrary.generated.swift
@@ -239,6 +239,23 @@ struct OptionalBSOf<T>: Arbitrary where T: Arbitrary & BoundedSemilattice & Equa
     }
 }
 
+struct OptionalBSFOf<T>: Arbitrary where T: Arbitrary & BoundedSemilattice & EquatableInContext {
+    let get: OptionalBSF<T>
+    init(_ get: OptionalBSF<T>) {
+        self.get = get
+    }
+
+    public static var arbitrary: Gen<OptionalBSFOf<T>> {
+        return Gen<OptionalBSF<T>>
+            .compose {
+                OptionalBSF<T>.init(
+                    unwrap: $0.generate(using: OptionalOf<T>.arbitrary.map { $0.getOptional })
+                )
+            }
+            .map(OptionalBSFOf<T>.init)
+    }
+}
+
 struct OptionalCMOf<T>: Arbitrary where T: Arbitrary & CommutativeMonoid & Equatable {
     let get: OptionalCM<T>
     init(_ get: OptionalCM<T>) {

--- a/Tests/Utility/Arbitrary.generated.swift
+++ b/Tests/Utility/Arbitrary.generated.swift
@@ -256,6 +256,23 @@ struct OptionalCMOf<T>: Arbitrary where T: Arbitrary & CommutativeMonoid & Equat
     }
 }
 
+struct OptionalCMFOf<T>: Arbitrary where T: Arbitrary & CommutativeMonoid & EquatableInContext {
+    let get: OptionalCMF<T>
+    init(_ get: OptionalCMF<T>) {
+        self.get = get
+    }
+
+    public static var arbitrary: Gen<OptionalCMFOf<T>> {
+        return Gen<OptionalCMF<T>>
+            .compose {
+                OptionalCMF<T>.init(
+                    unwrap: $0.generate(using: OptionalOf<T>.arbitrary.map { $0.getOptional })
+                )
+            }
+            .map(OptionalCMFOf<T>.init)
+    }
+}
+
 struct OptionalEqOf<T>: Arbitrary where T: Arbitrary & Equatable {
     let get: OptionalEq<T>
     init(_ get: OptionalEq<T>) {

--- a/Tests/Utility/Arbitrary.generated.swift
+++ b/Tests/Utility/Arbitrary.generated.swift
@@ -69,6 +69,23 @@ struct FirstOf<T>: Arbitrary where T: Arbitrary & Equatable {
     }
 }
 
+struct FirstFOf<T>: Arbitrary where T: Arbitrary & EquatableInContext {
+    let get: FirstF<T>
+    init(_ get: FirstF<T>) {
+        self.get = get
+    }
+
+    public static var arbitrary: Gen<FirstFOf<T>> {
+        return Gen<FirstF<T>>
+            .compose {
+                FirstF<T>.init(
+                    unwrap: $0.generate()
+                )
+            }
+            .map(FirstFOf<T>.init)
+    }
+}
+
 struct FirstMOf<T>: Arbitrary where T: Arbitrary & Monoid & Equatable {
     let get: FirstM<T>
     init(_ get: FirstM<T>) {
@@ -100,6 +117,23 @@ struct LastOf<T>: Arbitrary where T: Arbitrary & Equatable {
                 )
             }
             .map(LastOf<T>.init)
+    }
+}
+
+struct LastFOf<T>: Arbitrary where T: Arbitrary & EquatableInContext {
+    let get: LastF<T>
+    init(_ get: LastF<T>) {
+        self.get = get
+    }
+
+    public static var arbitrary: Gen<LastFOf<T>> {
+        return Gen<LastF<T>>
+            .compose {
+                LastF<T>.init(
+                    unwrap: $0.generate()
+                )
+            }
+            .map(LastFOf<T>.init)
     }
 }
 
@@ -253,6 +287,23 @@ struct OptionalSOf<T>: Arbitrary where T: Arbitrary & Semigroup & Equatable {
                 )
             }
             .map(OptionalSOf<T>.init)
+    }
+}
+
+struct OptionalSFOf<T>: Arbitrary where T: Arbitrary & Semigroup & EquatableInContext {
+    let get: OptionalSF<T>
+    init(_ get: OptionalSF<T>) {
+        self.get = get
+    }
+
+    public static var arbitrary: Gen<OptionalSFOf<T>> {
+        return Gen<OptionalSF<T>>
+            .compose {
+                OptionalSF<T>.init(
+                    unwrap: $0.generate()
+                )
+            }
+            .map(OptionalSFOf<T>.init)
     }
 }
 

--- a/Tests/Utility/Arbitrary.generated.swift
+++ b/Tests/Utility/Arbitrary.generated.swift
@@ -52,6 +52,23 @@ struct ArrayEqOf<T>: Arbitrary where T: Arbitrary & Equatable {
     }
 }
 
+struct ArrayEqFOf<T>: Arbitrary where T: Arbitrary & EquatableInContext {
+    let get: ArrayEqF<T>
+    init(_ get: ArrayEqF<T>) {
+        self.get = get
+    }
+
+    public static var arbitrary: Gen<ArrayEqFOf<T>> {
+        return Gen<ArrayEqF<T>>
+            .compose {
+                ArrayEqF<T>.init(
+                    unwrap: $0.generate(using: ArrayOf<T>.arbitrary.map { $0.getArray })
+                )
+            }
+            .map(ArrayEqFOf<T>.init)
+    }
+}
+
 struct FirstOf<T>: Arbitrary where T: Arbitrary & Equatable {
     let get: First<T>
     init(_ get: First<T>) {
@@ -256,6 +273,23 @@ struct OptionalEqOf<T>: Arbitrary where T: Arbitrary & Equatable {
     }
 }
 
+struct OptionalEqFOf<T>: Arbitrary where T: Arbitrary & EquatableInContext {
+    let get: OptionalEqF<T>
+    init(_ get: OptionalEqF<T>) {
+        self.get = get
+    }
+
+    public static var arbitrary: Gen<OptionalEqFOf<T>> {
+        return Gen<OptionalEqF<T>>
+            .compose {
+                OptionalEqF<T>.init(
+                    unwrap: $0.generate(using: OptionalOf<T>.arbitrary.map { $0.getOptional })
+                )
+            }
+            .map(OptionalEqFOf<T>.init)
+    }
+}
+
 struct OptionalMOf<T>: Arbitrary where T: Arbitrary & Semigroup & Equatable {
     let get: OptionalM<T>
     init(_ get: OptionalM<T>) {
@@ -270,6 +304,23 @@ struct OptionalMOf<T>: Arbitrary where T: Arbitrary & Semigroup & Equatable {
                 )
             }
             .map(OptionalMOf<T>.init)
+    }
+}
+
+struct OptionalMFOf<T>: Arbitrary where T: Arbitrary & Semigroup & EquatableInContext {
+    let get: OptionalMF<T>
+    init(_ get: OptionalMF<T>) {
+        self.get = get
+    }
+
+    public static var arbitrary: Gen<OptionalMFOf<T>> {
+        return Gen<OptionalMF<T>>
+            .compose {
+                OptionalMF<T>.init(
+                    unwrap: $0.generate(using: OptionalOf<T>.arbitrary.map { $0.getOptional })
+                )
+            }
+            .map(OptionalMFOf<T>.init)
     }
 }
 

--- a/Tests/Utility/CustomArbitraryTypes.swift
+++ b/Tests/Utility/CustomArbitraryTypes.swift
@@ -29,6 +29,33 @@ struct TestStructure: Arbitrary, BoundedSemilattice, Equatable {
 	}
 }
 
+struct TestFunction: Arbitrary, BoundedSemilattice, EquatableInContext {
+	typealias Context = String
+	let get: FunctionBS<String,Max<Int>>
+
+	init(_ value: @escaping (String) -> Max<Int>) {
+		self.get = FunctionBS.init(value)
+	}
+
+	static var arbitrary: Gen<TestFunction> {
+		return ArrowOf<String,MaxOf<Int>>.arbitrary
+			.map { f in { f.getArrow($0).get } }
+			.map(TestFunction.init)
+	}
+
+	static func <> (left: TestFunction, right: TestFunction) -> TestFunction {
+		return TestFunction((left.get <> right.get).unwrap)
+	}
+
+	static var empty: TestFunction {
+		return TestFunction.init { _ in Max<Int>.empty }
+	}
+
+	static func == (left: TestFunction, right: TestFunction) -> (Context) -> Bool {
+		return left.get == right.get
+	}
+}
+
 struct TestSemiring: Arbitrary, Semiring, Equatable {
 	typealias Additive = Bool.Additive
 	typealias Multiplicative = Bool.Multiplicative


### PR DESCRIPTION
This pull request contains definitions for types that give special semantics to function wrappers.

For example, it is defined an `OptionalSF` type that works like `OptionalS` but requires a wrapped value that's `EquatableInContext`, and it's `EquatableInContext` itself.

This can be used for example to wrap a `FunctionS` in `OptionalSF`: this couldn't be done in `OptionalS` because the requirement for the wrapped type of `OptionalS` is to be `Equatable`.

As usual, tests are defined for everything: Sourcery was particularly useful in this case because most of these wrappers really look like their `Equatable` counterparts.

Many of these wrapper types will be simplified once we get conditional protocol conformance in Swift, but until then they can be useful.